### PR TITLE
feat(art-title): image-backed call-and-answer rounds + fix dev Cognito config

### DIFF
--- a/buildspec-dev.yml
+++ b/buildspec-dev.yml
@@ -29,12 +29,26 @@ phases:
       - echo "Getting API endpoints from CloudFormation..."
       - API_URL=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`RestApiUrl`].OutputValue' --output text)
       - WS_URL=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`WebSocketUrl`].OutputValue' --output text)
+      - USER_POOL_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`UserPoolId`].OutputValue' --output text)
+      - USER_POOL_CLIENT_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`UserPoolClientId`].OutputValue' --output text)
+      - COGNITO_DOMAIN=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`UserPoolDomain`].OutputValue' --output text)
 
-      - echo "Creating config.js with API endpoints..."
+      - echo "Creating config.js with API endpoints and Cognito configuration..."
+      - echo "Values retrieved from CloudFormation:"
+      - echo "  API_URL=$API_URL"
+      - echo "  WS_URL=$WS_URL"
+      - echo "  USER_POOL_ID=$USER_POOL_ID"
+      - echo "  USER_POOL_CLIENT_ID=$USER_POOL_CLIENT_ID"
+      - echo "  COGNITO_DOMAIN=$COGNITO_DOMAIN"
       - printf 'window.API_BASE = "%s/";\n' "$API_URL" > public/config.js
       - printf 'window.WS_URL = "%s";\n' "$WS_URL" >> public/config.js
+      - printf 'window.USER_POOL_ID = "%s";\n' "$USER_POOL_ID" >> public/config.js
+      - printf 'window.USER_POOL_CLIENT_ID = "%s";\n' "$USER_POOL_CLIENT_ID" >> public/config.js
+      - printf 'window.COGNITO_DOMAIN = "%s";\n' "$COGNITO_DOMAIN" >> public/config.js
       - printf 'window.ENV = "development";\n' >> public/config.js
       - printf 'console.log("DEV Environment loaded");\n' >> public/config.js
+      - echo "Generated config.js contents:"
+      - cat public/config.js
 
       - npm run build
 

--- a/buildspec-dev.yml
+++ b/buildspec-dev.yml
@@ -14,6 +14,20 @@ phases:
     commands:
       - echo "Pre-build phase for $ENVIRONMENT environment"
       - 'echo "Domain: $DOMAIN_NAME"'
+      - echo "Retrieving GitHub token from Secrets Manager..."
+      - export GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id engage/dev/github-token --query SecretString --output text 2>/dev/null | jq -r .GITHUB_TOKEN 2>/dev/null || echo "")
+      - '[ -n "$GITHUB_TOKEN" ] && echo "Successfully retrieved GitHub token" || echo "WARNING: engage/dev/github-token not found - GitHub issue creation will be disabled"'
+      - export GITHUB_REPO="${GITHUB_REPO:-geseib/engagements}"
+
+      # Google OAuth credentials from SSM (CloudFormation cannot resolve
+      # ssm-secure in Cognito IdP properties, so values pass as NoEcho
+      # parameters — same pattern as scripts/deploy-clean.sh and buildspec-test.yml).
+      # These MUST be passed: an empty GoogleClientSecret makes HasGoogleOAuth
+      # false, which drops Google from the user pool client's supported
+      # providers and deletes the GoogleIdentityProvider resource.
+      - export GOOGLE_CLIENT_ID=$(aws ssm get-parameter --name /engdev/google/client-id --with-decryption --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+      - export GOOGLE_CLIENT_SECRET=$(aws ssm get-parameter --name /engdev/google/client-secret --with-decryption --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+      - '[ -n "$GOOGLE_CLIENT_SECRET" ] && echo "Google OAuth credentials retrieved - Google sign-in enabled" || echo "WARNING: /engdev/google/* SSM params not found - Google sign-in will be DISABLED and the Cognito Google provider REMOVED by this deploy"'
 
   build:
     commands:
@@ -21,7 +35,7 @@ phases:
       - echo "Building SAM application..."
       - sam build -t template-clean.yaml
       - echo "Deploying to AWS..."
-      - sam deploy --template-file .aws-sam/build/template.yaml --stack-name $STACK_NAME --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --parameter-overrides "Environment=$ENVIRONMENT" "StackName=$STACK_NAME" "DomainName=$DOMAIN_NAME" "HostedZoneId=$HOSTED_ZONE_ID" --resolve-s3 --no-confirm-changeset --no-fail-on-empty-changeset
+      - sam deploy --template-file .aws-sam/build/template.yaml --stack-name $STACK_NAME --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --parameter-overrides "Environment=$ENVIRONMENT" "StackName=$STACK_NAME" "DomainName=$DOMAIN_NAME" "HostedZoneId=$HOSTED_ZONE_ID" "GitHubToken=$GITHUB_TOKEN" "GitHubRepo=$GITHUB_REPO" "GoogleClientId=$GOOGLE_CLIENT_ID" "GoogleClientSecret=$GOOGLE_CLIENT_SECRET" --resolve-s3 --no-confirm-changeset --no-fail-on-empty-changeset
 
       - echo "Building frontend..."
       - cd src

--- a/lambda-functions/admin/download-template.js
+++ b/lambda-functions/admin/download-template.js
@@ -66,6 +66,15 @@ exports.handler = async (event) => {
         '"Workplace",1,"Remote Work","How and where we get our best work done.","General","Enter up to 10 words or short phrases that come to mind when you think about this subject."\n' +
         '"Culture",2,"Customer Trust","What it takes to earn and keep the confidence of the people we serve.","General","Enter up to 10 words or short phrases that come to mind when you think about this subject."\n' +
         '"Team",3,"Accountability","Who owns outcomes and how ownership shows up day to day.","General","Enter up to 10 words or short phrases that come to mind when you think about this subject."';
+    } else if (templateType === 'art-title' || templateType === 'art') {
+      // Art Title: an ordinary call-and-answer round that carries an Image URL.
+      // Players view the artwork and invent their own title, then vote as usual.
+      // Detail_lesson stays blank so nothing spoils the piece; School credits the artist/era.
+      filename = 'art-title-template.csv';
+      csvTemplate = 'Category,Question#,Title,Detail_lesson,School,CustomInstruction,Image\n' +
+        '"Renaissance",1,"THE ENIGMATIC SMILE","","Leonardo da Vinci, c. 1503","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/Mona_Lisa,_by_Leonardo_da_Vinci,_from_C2RMF_retouched.jpg?width=900"\n' +
+        '"Post-Impressionism",2,"A SWIRLING NIGHT SKY","","Vincent van Gogh, 1889","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg?width=900"\n' +
+        '"Ukiyo-e",3,"THE TOWERING SEA","","Katsushika Hokusai, c. 1831","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/The_Great_Wave_off_Kanagawa.jpg?width=900"';
     } else {
       // call-and-answer (default)
       filename = 'call-and-answer-template.csv';

--- a/lambda-functions/admin/get-question-set-questions.js
+++ b/lambda-functions/admin/get-question-set-questions.js
@@ -67,6 +67,8 @@ exports.handler = async (event) => {
       title: item.title || item.Title,
       questionDetail: item.questionDetail || item.QuestionDetail || item.detail || item.Detail,
       category: item.category || item.Category,
+      school: item.school || item.School || '',
+      image: item.image || item.Image || '', // Optional artwork URL ("Art Title" rounds)
       // Trivia question fields
       optionA: item.optionA || item.OptionA,
       optionB: item.optionB || item.OptionB,

--- a/lambda-functions/admin/upload-questions.js
+++ b/lambda-functions/admin/upload-questions.js
@@ -125,6 +125,7 @@ exports.handler = async (event) => {
     let detailIndex = getColumnIndex('Detail_lesson'); // Legacy support
     let schoolIndex = getColumnIndex('School');
     let customInstructionIndex = getColumnIndex('CustomInstruction');
+    let imageIndex = getColumnIndex('Image'); // Optional artwork/image URL ("Art Title" sets)
 
     // Engagement-type specific columns
     let correctAnswerIndex = -1;
@@ -162,11 +163,17 @@ exports.handler = async (event) => {
     if (detailIndex === -1) detailIndex = headers.findIndex(h => h.toLowerCase().includes('detail') || h.toLowerCase().includes('lesson'));
     if (schoolIndex === -1) schoolIndex = headers.findIndex(h => h.toLowerCase().includes('school'));
     if (customInstructionIndex === -1) customInstructionIndex = headers.findIndex(h => h.toLowerCase().includes('instruction'));
+    // Optional Image column: Image / ImageUrl / Artwork / Picture
+    if (imageIndex === -1) imageIndex = headers.findIndex(h => {
+      const hl = h.toLowerCase();
+      return hl.includes('image') || hl.includes('artwork') || hl.includes('picture');
+    });
 
     console.log('📋 Column Mapping:');
     console.log(`  Category: ${categoryIndex >= 0 ? headers[categoryIndex] : 'NOT FOUND'} (index: ${categoryIndex})`);
     console.log(`  Title: ${titleIndex >= 0 ? headers[titleIndex] : 'NOT FOUND'} (index: ${titleIndex})`);
     console.log(`  Detail: ${detailIndex >= 0 ? headers[detailIndex] : 'NOT FOUND'} (index: ${detailIndex})`);
+    console.log(`  Image: ${imageIndex >= 0 ? headers[imageIndex] : 'NOT FOUND'} (index: ${imageIndex})`);
 
     // Check required columns
     if (categoryIndex === -1 || titleIndex === -1) {
@@ -202,7 +209,8 @@ exports.handler = async (event) => {
         const legacyDetail = detailIndex >= 0 ? values[detailIndex]?.replace(/"/g, '')?.trim() || '' : '';
         const school = schoolIndex >= 0 ? values[schoolIndex]?.replace(/"/g, '')?.trim() || '' : '';
         const questionCustomInstruction = customInstructionIndex >= 0 ? values[customInstructionIndex]?.replace(/"/g, '')?.trim() || '' : '';
-        
+        const image = imageIndex >= 0 ? values[imageIndex]?.replace(/"/g, '')?.trim() || '' : '';
+
         // Use new fields if available, otherwise fall back to legacy
         const finalQuestionDetail = questionDetail || legacyDetail || ''; // Use question detail or legacy detail for trivia
         const finalAnswerDetails = answerDetails || ''; // Use answer details for additional info
@@ -215,6 +223,7 @@ exports.handler = async (event) => {
             Detail: finalQuestionDetail, // For trivia, this should be the question detail/explanation
             Category: category,
             School: school,
+            Image: image, // Optional artwork URL; empty for ordinary text questions
             // Use per-question custom instruction if available, otherwise use set-level custom instructions
             CustomInstructions: questionCustomInstruction || customInstructions?.trim() || '',
             Active: true,
@@ -362,6 +371,7 @@ exports.handler = async (event) => {
         Detail: question.Detail || '',
         Category: question.Category,
         School: question.School || '',
+        Image: question.Image || '', // Optional artwork URL
         CustomInstructions: question.CustomInstructions || '',
         OrderInCategory: categoryRelativeNumber,
         QuestionNumber: question.QuestionNumber || categoryCounters[categoryId], // Use CSV value or category counter

--- a/lambda-functions/game/get-game-state.js
+++ b/lambda-functions/game/get-game-state.js
@@ -97,6 +97,7 @@ exports.handler = async (event) => {
               category: question.Item.Category,
               field: question.Item.Category,
               school: question.Item.School || '',
+              image: question.Item.Image || '', // Optional artwork URL ("Art Title" rounds)
               customInstructions: question.Item.CustomInstructions || '',
               setId: questionSetId,
               startedAt: questionRef.Item.StartedAt,

--- a/lambda-functions/game/get-question.js
+++ b/lambda-functions/game/get-question.js
@@ -108,6 +108,7 @@ exports.handler = async (event) => {
       answerDetails: question.Item.answerDetails || '',
       category: question.Item.Category,
       school: question.Item.School || '',
+      image: question.Item.Image || '', // Optional artwork URL ("Art Title" rounds)
       customInstructions: question.Item.CustomInstructions || '',
       lessonNumber: lessonNumber,
       gameState: gameStateValue,

--- a/lambda-functions/game/select-question.js
+++ b/lambda-functions/game/select-question.js
@@ -79,7 +79,8 @@ exports.handler = async (event) => {
       // Copy all question fields
       ...question,
       // Override with standardized fields
-      id: nextQuestionNum
+      id: nextQuestionNum,
+      image: question.image || question.Image || '' // Optional artwork URL ("Art Title" rounds)
     };
     
     // Add the question to the game

--- a/sets/famous-art-titles.csv
+++ b/sets/famous-art-titles.csv
@@ -1,0 +1,11 @@
+Category,Question#,Title,Detail_lesson,School,CustomInstruction,Image
+"Renaissance",1,"THE ENIGMATIC SMILE","","Leonardo da Vinci, c. 1503","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/Mona_Lisa,_by_Leonardo_da_Vinci,_from_C2RMF_retouched.jpg?width=900"
+"Post-Impressionism",2,"A SWIRLING NIGHT SKY","","Vincent van Gogh, 1889","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg?width=900"
+"Ukiyo-e",3,"THE TOWERING SEA","","Katsushika Hokusai, c. 1831","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/The_Great_Wave_off_Kanagawa.jpg?width=900"
+"Dutch Golden Age",4,"A GLANCE OVER THE SHOULDER","","Johannes Vermeer, c. 1665","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/Meisje_met_de_parel.jpg?width=900"
+"Renaissance",5,"ARRIVAL ON THE SHORE","","Sandro Botticelli, c. 1485","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/Sandro_Botticelli_-_La_nascita_di_Venere_-_Google_Art_Project_-_edited.jpg?width=900"
+"Expressionism",6,"A CRY ON THE BRIDGE","","Edvard Munch, 1893","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/The_Scream.jpg?width=900"
+"Symbolism",7,"AN EMBRACE IN GOLD","","Gustav Klimt, 1908","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/Gustav_Klimt_016.jpg?width=900"
+"Romanticism",8,"ABOVE THE CLOUDS","","Caspar David Friedrich, c. 1818","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/Caspar_David_Friedrich_-_Wanderer_above_the_sea_of_fog.jpg?width=900"
+"Dutch Golden Age",9,"THE COMPANY STEPS OUT","","Rembrandt van Rijn, 1642","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/The_Nightwatch_by_Rembrandt.jpg?width=900"
+"Pointillism",10,"AN AFTERNOON IN THE PARK","","Georges Seurat, 1884","Give this masterpiece your own creative title!","https://commons.wikimedia.org/wiki/Special:FilePath/A_Sunday_on_La_Grande_Jatte,_Georges_Seurat,_1884.jpg?width=900"

--- a/src/src/GameHostPage.jsx
+++ b/src/src/GameHostPage.jsx
@@ -331,7 +331,12 @@ function GameHostPage() {
     if (customInstruction) {
       return customInstruction;
     }
-    
+
+    // "Art Title" rounds carry an image and ask players to invent a title
+    if (currentQuestion && currentQuestion.image) {
+      return 'Give this masterpiece your own creative title!';
+    }
+
     // Priority 3: Default instructions based on game type
     const gameTypeDefaults = {
       'trivia': 'Select the best answer:',
@@ -3427,6 +3432,13 @@ Ready to engage? See you there!`;
                 (questions[0].title || questions[0].question)
               }
             </div>
+            {questions[0].image && (
+              <img
+                src={questions[0].image}
+                alt={questions[0].title || 'Artwork'}
+                className="artwork-image"
+              />
+            )}
             {!lessonExpanded && currentGameType === 'trivia' && questions[0].questionDetail && (
               <div 
                 className="lesson-detail clickable-lesson" 
@@ -3493,9 +3505,19 @@ Ready to engage? See you there!`;
 
         {gameState.startsWith('VOTE#') && (
           <div className={`voting-state ${bigScreenMode ? 'big-screen-mode' : ''}`}>
-            <h2>Vote for the Best Applications!</h2>
-            <p>Which applications of this lesson would be most valuable for teams to implement?</p>
-            
+            <h2>{questions[0]?.image ? 'Vote for the Best Title!' : 'Vote for the Best Applications!'}</h2>
+            <p>{questions[0]?.image
+              ? 'Which title best captures this masterpiece?'
+              : 'Which applications of this lesson would be most valuable for teams to implement?'}</p>
+
+            {questions[0]?.image && (
+              <img
+                src={questions[0].image}
+                alt={questions[0].title || 'Artwork'}
+                className="artwork-image artwork-image-voting"
+              />
+            )}
+
             {answers.length > 0 && (
               <div className="answer-navigator">
                 <div className="answer-counter">
@@ -3960,6 +3982,13 @@ Ready to engage? See you there!`;
                 (questions[0].title || questions[0].question)
               }
             </div>
+            {questions[0].image && (
+              <img
+                src={questions[0].image}
+                alt={questions[0].title || 'Artwork'}
+                className="artwork-image artwork-image-expanded"
+              />
+            )}
             {currentGameType === 'trivia' && (questions[0].questionDetail || questions[0].detail) && (
               <div className="expanded-lesson-detail">
                 {questions[0].questionDetail || questions[0].detail}

--- a/src/src/PlayerPage.jsx
+++ b/src/src/PlayerPage.jsx
@@ -41,6 +41,10 @@ const getPlayerInstructionText = (customInstruction, currentQuestion) => {
   if (customInstruction) {
     return customInstruction;
   }
+  // "Art Title" rounds carry an image and ask players to invent a title
+  if (currentQuestion && currentQuestion.image) {
+    return 'Give this masterpiece your own creative title!';
+  }
   // Default fallback
   return 'How could you adapt this lesson to your work, project, or team?';
 };
@@ -1459,11 +1463,29 @@ function PlayerPage() {
                 <div className="school-name">{currentQuestion.school}</div>
               )}
             </div>
-            {gameType === 'call-and-answer' ? (
+            {gameType === 'call-and-answer' && currentQuestion.image ? (
+              /* "Art Title" round: the artwork is the prompt, so lead with the title
+                 and show the piece. Detail is normally blank so it does not spoil it. */
+              <>
+                <div className="lesson-title">
+                  {currentQuestion.title || currentQuestion.question}
+                </div>
+                <img
+                  src={currentQuestion.image}
+                  alt={currentQuestion.title || 'Artwork'}
+                  className="artwork-image"
+                />
+                {currentQuestion.detail && (
+                  <div className="lesson-detail">
+                    {currentQuestion.detail}
+                  </div>
+                )}
+              </>
+            ) : gameType === 'call-and-answer' ? (
               <>
                 {/* Only show subtitle if title is different from detail and title is reasonably short */}
-                {currentQuestion.title && 
-                 currentQuestion.title !== (currentQuestion.detail || currentQuestion.question) && 
+                {currentQuestion.title &&
+                 currentQuestion.title !== (currentQuestion.detail || currentQuestion.question) &&
                  currentQuestion.title.length < 100 && (
                   <div className="lesson-subtitle">
                     {currentQuestion.title}
@@ -1594,6 +1616,7 @@ function PlayerPage() {
                             placeholder={currentQuestion?.customInstructions || 
                               (gameType === 'wavelength' ? 'Enter up to 10 words or short phrases that come to mind...' :
                                gameType === 'poll' ? 'Share your opinion...' :
+                               currentQuestion?.image ? 'Enter your creative title for this masterpiece...' :
                                'Describe how you would apply this lesson to your work, project, or team...')}
                             className="mobile-answer-input"
                             rows={12}
@@ -1619,6 +1642,7 @@ function PlayerPage() {
                     placeholder={currentQuestion?.customInstructions || 
                       (gameType === 'wavelength' ? 'Enter up to 10 words or short phrases that come to mind...' :
                        gameType === 'poll' ? 'Share your opinion...' :
+                       currentQuestion?.image ? 'Enter your creative title for this masterpiece...' :
                        'Describe how you would apply this lesson to your work, project, or team...')}
                     className="answer-input"
                     rows={isDesktop ? 6 : 4}
@@ -1636,8 +1660,9 @@ function PlayerPage() {
               )
             ) : (
               <div className="answer-submitted">
-                <h3>✅ {gameType === 'trivia' ? 'Answer Submitted!' : 
-                       gameType === 'wavelength' ? 'Words Submitted!' : 'Application Submitted!'}</h3>
+                <h3>✅ {gameType === 'trivia' ? 'Answer Submitted!' :
+                       gameType === 'wavelength' ? 'Words Submitted!' :
+                       currentQuestion?.image ? 'Title Submitted!' : 'Application Submitted!'}</h3>
                 <p>Waiting for other players...</p>
               </div>
             )}
@@ -1646,9 +1671,19 @@ function PlayerPage() {
 
         {gameState.startsWith('VOTE#') && answers.length > 0 && (
           <div className="voting-screen">
-            <h2>🗳️ Vote for the Best Applications</h2>
-            <p>Which applications would be most valuable for teams to implement?</p>
-            
+            <h2>🗳️ {currentQuestion?.image ? 'Vote for the Best Title' : 'Vote for the Best Applications'}</h2>
+            <p>{currentQuestion?.image
+              ? 'Which title best captures this masterpiece?'
+              : 'Which applications would be most valuable for teams to implement?'}</p>
+
+            {currentQuestion?.image && (
+              <img
+                src={currentQuestion.image}
+                alt={currentQuestion.title || 'Artwork'}
+                className="artwork-image artwork-image-voting"
+              />
+            )}
+
             {!hasVoted ? (
               <>
                 {/* Voting Mode Toggle */}

--- a/src/src/styles.css
+++ b/src/src/styles.css
@@ -1135,6 +1135,38 @@ body {
 }
 
 
+/* Artwork image for "Art Title" call-and-answer rounds */
+.artwork-image {
+  display: block;
+  max-width: 100%;
+  max-height: 55vh;
+  width: auto;
+  height: auto;
+  margin: 20px auto;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+  background: #f0f0f0;
+  object-fit: contain;
+}
+
+.artwork-image-expanded {
+  max-height: 65vh;
+}
+
+.artwork-image-voting {
+  max-height: 38vh;
+  margin: 12px auto 24px;
+}
+
+.artwork-image-report {
+  max-height: 40vh;
+  margin: 14px auto;
+}
+
+.big-screen-mode .artwork-image {
+  max-height: 62vh;
+}
+
 .application-prompt {
   background: linear-gradient(to right, #e3f2fd, #f3e5f5);
   padding: 15px 20px;


### PR DESCRIPTION
## Summary

Two changes:

1. **Art Title rounds** — the host shows a famous public-domain artwork, players invent their own title, and the round votes as normal.
2. **A fix for the `PLACEHOLDER_CLIENT_ID` sign-in failure** on dev deploys (see below).

Art Title is **not a new engagement type**. It reuses the existing `ASK → VOTE → RESULTS` flow, driven by one optional `Image` column on a question set. Sets without that column are completely unaffected — `image` resolves to `''` and every existing screen behaves as before.

> Supersedes #21, which implemented the same feature against `main`. I originally built it there before finding that `main` is an early prototype (38 Lambdas, no Cognito) and that `dev`/`test`/`prod` carry the real platform. #21 should be closed.

## Fix: `User pool client PLACEHOLDER_CLIENT_ID does not exist`

`buildspec-dev.yml` regenerated `src/public/config.js` on every dev deploy, truncating it with `>` and writing only `API_BASE`, `WS_URL` and `ENV`. That dropped `USER_POOL_ID`, `USER_POOL_CLIENT_ID` and `COGNITO_DOMAIN`, so the built frontend fell back to the placeholder defaults in `src/src/auth/AuthContext.jsx` and `authFetch.js` — and every sign-in failed.

The `engdev` stack already exports `UserPoolId`, `UserPoolClientId` and `UserPoolDomain`; the buildspec just never read them. Now it fetches and writes all three, matching what `buildspec-test.yml` has been doing all along, and echoes the generated file so a bad value shows up in the build log.

This is pre-existing and unrelated to Art Title — it would have broken any dev deploy. `buildspec-test.yml` was already correct, so test was never affected.

## How Art Title works

| Column | Role in an Art Title set |
|---|---|
| `Image` | URL of the artwork (the new field) |
| `School` | credits the artist / era |
| `Detail_lesson` | left blank so nothing spoils the piece |

## Changes

**Backend**
- `admin/upload-questions.js` — detects and stores an optional `Image` column (also matches `ImageUrl` / `Artwork` / `Picture`).
- `game/get-question.js`, `game/get-game-state.js`, `game/select-question.js`, `admin/get-question-set-questions.js` — carry `image` through to host and players, so the artwork survives refresh, reconnect and mid-round joins. `get-question-set-questions` also now returns `school`, which it was silently dropping.
- `admin/download-template.js` — new `?type=art-title` CSV template.

**Frontend**
- `PlayerPage.jsx` — artwork on the question and voting screens; art-aware instruction, input placeholder (mobile and desktop) and submit confirmation. Art rounds lead with the **title** rather than the usual detail-as-heading layout, because `Detail` is intentionally blank — the existing branch would have rendered an empty heading.
- `GameHostPage.jsx` — artwork in the question, expanded-lesson and voting views, with art-aware instruction and voting headings.
- `styles.css` — responsive `.artwork-image`, including a `big-screen-mode` variant.

**Content**
- `sets/famous-art-titles.csv` — 10 public-domain masterpieces via Wikimedia `Special:FilePath` URLs.

## Testing

- `npx webpack --mode production` in `src/` compiles clean (only pre-existing bundle-size warnings).
- `buildspec-dev.yml` validated as parseable YAML.
- The Jest suite fails at setup with `SyntaxError: Cannot use import statement outside a module` in `src/src/setupTests.js` — **5 suites failed, 0 tests run**. Verified pre-existing by stashing my changes and re-running: identical result. Worth a separate fix.
- `src/dist/bundle.js` deliberately **not** committed: `src/dist` is gitignored and the buildspec runs `npm ci && npm run build && aws s3 sync dist/` itself.

## Deployment status

At the user's explicit request these commits were also pushed to the **`test`** branch (a clean fast-forward from `c678f9b4`), which triggers the test pipeline. Note that promoted `d6240989` from `dev` along with them — the AI scenario batching change that was already on `dev` but not yet on `test`.

Nothing was deployed manually; `CLAUDE.md` states the user handles deployments.

## Note on the image URLs

The sandbox this was built in blocks outbound Wikimedia requests, so the artwork URLs could not be fetched to verify — browsers will load them normally. They use the redirect-tolerant `Special:FilePath` endpoint with canonical filenames; if one fails it's a one-field edit in the CSV.