### PR TITLE
fix(wavelength): Field Notes crashed on every wavelength round

### DIFF
--- a/docs/handoff/RESUME.md
+++ b/docs/handoff/RESUME.md
@@ -1,0 +1,38 @@
+# Resume prompt
+
+After `/clear`, paste the block below.
+
+---
+
+Read these three files before doing anything else, in this order:
+
+1. `docs/handoff/anonymous-responses-2026-08-09.md` — current state, baselines, landmines, what is deliberately NOT pushed and why
+2. `.superpowers/sdd/2026-08-09-anonymous-responses/progress.md` — the SDD ledger: per-task commits, review verdicts, deferred minors
+3. `docs/superpowers/plans/2026-08-09-anonymous-responses.md` — the plan being executed
+
+Then continue with `superpowers:subagent-driven-development`, executing that plan from **Task 6's review** onward. Tasks 1–5 are complete and review-clean; Task 6 is implemented (`f1d65470`) but has not passed its review gate. Tasks 7–11 are not started.
+
+Resume the loop exactly as the ledger describes:
+
+- Task 6 needs a review package generated over `8476e704..f1d65470` and a task reviewer dispatched, before Task 7 begins.
+- Work on `dev` directly. Do **not** create a worktree — worktrees here branch from `main` and this project's convention is to work on `dev`.
+- Do **not** push `dev` until Task 10 lands. The reason is in the handoff's "Do not deploy yet" section and it is not negotiable: Tasks 1–6 redact author names with the flag defaulting ON for every existing game, while the host UI gains no reveal control until Task 10.
+- Do **not** deploy anything. `CLAUDE.md` reserves that to the owner.
+
+Three hazards that already cost time this session — they are in the handoff but read them twice:
+
+- **Every `check(...)` in `tests/anonymous-round-flow.js` and `tests/anonymity-contract.js` must be `await`ed.** `check` is async; a bare call exits before the assertion resolves and vanishes from the pass count with no failure signal.
+- **`seedAnonymousRound` seeds no `CONNECTION#` rows.** Any test asserting on a broadcast must `put()` its own connection or the assertion passes vacuously against an empty `sent` array.
+- **A test that cannot fail proves nothing.** Task 5's padding fix needed a *revealed* round to be outcome-determining; an anonymous round would have passed either way. Verify new tests fail before the fix.
+
+Backend baseline to beat: **20 suites, 690 passed, 0 failed**. Aggregate with `grep -E '^[0-9]+ passed'`, never `tail -1`.
+
+Two things are outstanding on the owner and are not yours to do: approving the staged prod deploy, and running the last two `engagetest` migrations in the documented order.
+
+---
+
+## If you want the UX work instead
+
+Say so, and the resume prompt becomes:
+
+> Read `docs/superpowers/specs/2026-08-08-host-screen-redesign-design.md` (§8 has the implementation order, §7 has 18 testable negatives) and browse the approved mockups in `docs/design/host-redesign/` full-screen. Then use `superpowers:writing-plans` to write plan 2 — the stage shell: the fixed-height three-row grid, the four density ladders, and the `fit()` hook. Park the anonymous-responses plan where it is; tasks 1–5 are committed and reviewed, Task 6 is unreviewed, and the gate is inert until something calls it.

--- a/docs/handoff/anonymous-responses-2026-08-09.md
+++ b/docs/handoff/anonymous-responses-2026-08-09.md
@@ -12,7 +12,7 @@ SDD ledger: `.superpowers/sdd/2026-08-09-anonymous-responses/progress.md` (git-i
 
 | Suite | Command | Expected |
 |---|---|---|
-| Backend | `for t in tests/*.js; do node "$t"; done` | **20 suites, 690 passed, 0 failed** |
+| Backend | `for t in tests/*.js; do node "$t"; done` | **20 suites, 720 passed, 0 failed** |
 | Frontend | `cd src && npx jest __tests__/` | 5 failed suites / 30 failed / 242 passed |
 | Build | `cd src && npm run build` | compiles, 2 pre-existing size warnings |
 | Template | `sam validate --lint -t template-clean.yaml` | valid |
@@ -25,7 +25,16 @@ The 5 failing frontend suites are stale and out of scope: they predate the auth 
 
 ## Where anonymous responses got to
 
-**Tasks 1–6 of 11 are done.** The backend can now complete a full round — redact, vote, reveal. Tasks 7–11 are not started.
+**Tasks 1–8 of 11 are done and review-clean.** The whole backend is in. Task 9 is in flight; Tasks 10–11 are not started.
+
+### The rule changed mid-execution — read this before anything else
+
+**Owner decision, 2026-08-09.** The original design had names return only when the host tapped **Reveal**, and had the report withhold attribution forever for any round that was never revealed. Both are gone.
+
+- **Voting closing reveals the round.** `AuthorsRevealed` flips automatically when a round enters `RESULTS#nnn`, inside `enterResultsState` ([get-results.js:118](../../lambda-functions/game/get-results.js)) — the single choke point whose own doc comment records that this write used to be missing from the wavelength and zero-vote exits. The promise was always *"until voting closes"*; the build had drifted to *"until the host presses a button"*.
+- **The report attributes every round.** There is no unattributed-forever case. `create-report.js` is deliberately **untouched** — do not gate it.
+- **The gate binds only formats that hold a vote.** `isHidden` returns `false` for trivia and wavelength. This was a live defect, not tidiness: the flag defaults ON and every pre-feature game has no `HostPreferences`, so legacy **trivia** games were having their ASK answers redacted, which breaks the host's view of who answered what.
+- **`POST /reveal-authors` survives** as a manual override for a host who wants names back *before* closing the vote. It is no longer the only path, which is why Task 10 shrank: the on-stage reveal is now a display step over data that already carries names.
 
 | # | Task | Commit | Review |
 |---|---|---|---|
@@ -34,24 +43,23 @@ The 5 failing frontend suites are stale and out of scope: they predate the auth 
 | 3 | Redact `GET /games/{id}/answers` | `2c588841` + fix `6de72ea8` | clean after 1 fix round |
 | 4 | Redact `POST /games/{id}/start-vote` | `35a922be` | clean |
 | 5 | Redact the `playerAnswered` socket frame | `8476e704` + fix `f4c1a8ac` | clean after 1 fix round |
-| 6 | `POST /games/{id}/reveal-authors` | `f1d65470` | **not yet reviewed** |
+| 6 | `POST /games/{id}/reveal-authors` | `f1d65470` | clean |
+| 7 | Field Notes names nobody while hidden | `c01571fe` + fix `e3fc7711` | clean after 1 fix round |
+| 8 | Voting closing reveals; gate binds voting formats only | `afd5e7b4` | clean |
 
-**Task 6 has not completed its review gate.** Generate its review package with
-`<skill>/scripts/review-package docs/superpowers/plans/2026-08-09-anonymous-responses.md 8476e704 f1d65470`.
+Task 7 was larger than the plan predicted. The deterministic template was only half of it — the same authorship reached the Bedrock prompt through a **second** independent path (`results.voteTallies` / `winners`, built by the vote-tally scorer from the same raw rows), and a **third** for wavelength rounds via a cached `QUESTION#…#RESULTS` record that fed real names into the prompt *and* into the `?debug=true` response, which anyone can request. All three are gated now.
 
 ### Remaining tasks
 
-7. **Field Notes must not name an unrevealed author.** `get-ai-summary.js:1175-1176` builds `` `${top.playerName}'s answer, "${top.answer}", earned the most support` `` in code — a deterministic template, not the model. Needs an unattributed fallback while hidden, and the model prompt built from redacted rows.
-8. **The report must honour `AuthorsRevealed`.** `get-results.js:414` persists `Winners` by name, so the report can reconstruct attribution even when the response was redacted. A round never revealed must stay unattributed, or a promise made to the room is broken by an artefact produced after everyone leaves.
-9. **Setup control** — `src/src/config/anonymity.js` + the form. Offered only for formats that hold a vote, derived from `hostRunsVotePhase()` so the two cannot drift.
-10. **Host renders redacted rounds and drives the reveal** — plus hiding standings pre-reveal (attribution by arithmetic) and the `‹ Hide again` display-only step.
+9. **Setup control** — `src/src/config/anonymity.js` + the form. Offered only for formats that hold a vote, derived from `hostRunsVotePhase()` so the two cannot drift. *In flight.*
+10. **Host renders redacted rounds and drives the reveal** — smaller than planned. Because voting closing now reveals, the payload already carries names by the time RESULTS is on screen, so the on-stage reveal is a **display** step and `handleRevealAuthors` is only load-bearing when a host reveals *before* closing the vote. Still includes hiding standings pre-reveal (attribution by arithmetic) and the `‹ Hide again` display-only control.
 11. **Player ballot** — label by position, mark the player's own row by matching submitted text.
 
 ---
 
 ## Do not deploy yet
 
-`dev` is **held at `85ad6043`** on the remote. Local `dev` carries Tasks 1–6.
+`dev` is **held at `85ad6043`** on the remote. Local `dev` carries Tasks 1–8.
 
 Pushing now would deploy a backend that redacts author names with `anonymousUntilReveal` defaulting **ON for every existing game**, while the host UI has no reveal control (that is Task 10). Names would vanish from the vote and results views with no button to bring them back — recoverable only by calling `POST /games/{id}/reveal-authors` by hand.
 
@@ -97,6 +105,10 @@ All take `AWS_PROFILE=adminaccess node scripts/<name>.js engagetest [--apply]` a
 - **`message.js` routing makes `playerVoted` unreachable.** `isHostMessage` is checked before `isPlayerMessage` and both match a `VOTE#` prefix, so `handlePlayerMessage`'s `playerVoted` branch is dead code. Pre-existing, unrelated to anonymity, worth its own look.
 - **The ballot is positional and stable only by accident** (spec §5.6.5a, risk R1). `submit-vote.js:63` stores `{"0": 1, "1": 2}` and `get-results.js:276` tallies against `answers[index]`; the indices agree only because the answer sort key ends in the author's name. Any re-keying, or an answer arriving mid-round, silently lands votes on the wrong answers. **Independent of anonymity — do not bundle.**
 - **`reopen-round` does not exist** (risk R2). A host who advances early cannot recover.
+- **`get-ai-summary.js:866` references an undeclared `commonWords`** inside `exports.handler`'s wavelength vote-tally pass; the identifier is only declared inside `generateAISummary`. That is a `ReferenceError` at runtime, so wavelength AI summaries requested through the real handler almost certainly crash in production today. Pre-existing, unrelated to anonymity, confirmed untouched. Spawned as its own task.
+- **`?debug=true` on `get-ai-summary` returns the full assembled prompt and every template variable to any caller.** That is the surface the wavelength name leak reached the outside world through, and it will be the surface the next one reaches too. Anything added to a prompt is public by construction.
+- **A redaction that feeds prose cannot use the omit-don't-null contract.** `redactAnswer` deletes the field, which is right for a JSON payload and wrong for a template literal — an omitted field renders the string `"undefined"` into the prompt. `get-ai-summary.js` substitutes a flat `'a participant'` placeholder instead, at the single point authorship enters the function. Do not "simplify" that into a call to `redactAnswers`.
+- **A flat placeholder collides when it is used as a key.** `playerWordLists[playerName] = words` silently kept only the last participant once every name became the same string. Fixed by keying on an array index; the same trap waits anywhere a name is used as an object key.
 
 ### Deferred minors
 
@@ -111,9 +123,15 @@ All take `AWS_PROFILE=adminaccess node scripts/<name>.js engagetest [--apply]` a
 
 `docs/design/host-redesign/` — 21 mockups, `audit.js` (168 checks over 21 pages × 4 profiles × 2 viewports), `CRITIQUE.md`, `USER-REVIEWS.md`, `USER-REVIEWS-2.md`. Serve it with a static server on any port and open `index.html`; the type is `vh`-scaled so it only tells the truth full-screen.
 
-Reviewed to approval over four rounds — an independent critic and three simulated first-time evaluators who went from two hard noes to unanimous yes. Plans 2–5 are not written yet:
+Reviewed to approval over four rounds — an independent critic and three simulated first-time evaluators who went from two hard noes to unanimous yes.
 
-2. Stage shell + four profile ladders + the `fit()` hook
+**Plan 2 is now written:** [docs/superpowers/plans/2026-08-09-host-stage-shell.md](../superpowers/plans/2026-08-09-host-stage-shell.md). Five tasks — display profiles + ladders, the fitter's policy as pure functions, the `useStageFit` hook, the shell components, then GameHostPage adopting it plus the six deletions §8 names.
+
+**One correction to the spec, found while drafting it.** §8 says `audit.js` "is written to port into component tests unchanged." It is not portable to Jest: every check is geometric (`getBoundingClientRect`, `scrollHeight`, computed font size) and jsdom has no layout engine, so all of them return zero and the port would pass unconditionally — the exact failure mode §4.2b exists to warn about. The plan splits the guarantee: the fitter's *policy* (sacrifice order, the search, the truncation predicate — where all three shipped bugs actually were) becomes pure and is unit-tested; rendered geometry stays guarded by `audit.js` against the mockups. Running the audit against the React app needs a headless-browser harness this repo does not have, and that is recorded as separate work.
+
+Plans 3–5 are not written yet:
+
+2. ~~Stage shell + four profile ladders + the `fit()` hook~~ — written
 3. Console (operator chrome, question browser, how-to-play beat)
 4. Per-state content and the deletions
 5. ENDED, plus two verified defects — `isWaitingState('ENDED')` returns `true` so a finished session renders the lobby, and `setGameState('ENDED')` sits inside the `if (confirmed)` branch of the `gameEnded` dialog so declining strands the game.

--- a/docs/handoff/anonymous-responses-2026-08-09.md
+++ b/docs/handoff/anonymous-responses-2026-08-09.md
@@ -12,7 +12,7 @@ SDD ledger: `.superpowers/sdd/2026-08-09-anonymous-responses/progress.md` (git-i
 
 | Suite | Command | Expected |
 |---|---|---|
-| Backend | `for t in tests/*.js; do node "$t"; done` | **20 suites, 689 passed, 0 failed** |
+| Backend | `for t in tests/*.js; do node "$t"; done` | **20 suites, 690 passed, 0 failed** |
 | Frontend | `cd src && npx jest __tests__/` | 5 failed suites / 30 failed / 242 passed |
 | Build | `cd src && npm run build` | compiles, 2 pre-existing size warnings |
 | Template | `sam validate --lint -t template-clean.yaml` | valid |
@@ -33,7 +33,7 @@ The 5 failing frontend suites are stale and out of scope: they predate the auth 
 | 2 | `anonymousUntilReveal` persists through create | `37eae389` | clean |
 | 3 | Redact `GET /games/{id}/answers` | `2c588841` + fix `6de72ea8` | clean after 1 fix round |
 | 4 | Redact `POST /games/{id}/start-vote` | `35a922be` | clean |
-| 5 | Redact the `playerAnswered` socket frame | `8476e704` | **review was still running at handoff** |
+| 5 | Redact the `playerAnswered` socket frame | `8476e704` + fix `f4c1a8ac` | spec ❌ → fixed; re-review outstanding |
 | 6 | `POST /games/{id}/reveal-authors` | `f1d65470` | **not yet reviewed** |
 
 **Tasks 5 and 6 have not completed their review gate.** Re-run them before trusting either:

--- a/docs/handoff/anonymous-responses-2026-08-09.md
+++ b/docs/handoff/anonymous-responses-2026-08-09.md
@@ -33,16 +33,10 @@ The 5 failing frontend suites are stale and out of scope: they predate the auth 
 | 2 | `anonymousUntilReveal` persists through create | `37eae389` | clean |
 | 3 | Redact `GET /games/{id}/answers` | `2c588841` + fix `6de72ea8` | clean after 1 fix round |
 | 4 | Redact `POST /games/{id}/start-vote` | `35a922be` | clean |
-| 5 | Redact the `playerAnswered` socket frame | `8476e704` + fix `f4c1a8ac` | spec ❌ → fixed; re-review outstanding |
+| 5 | Redact the `playerAnswered` socket frame | `8476e704` + fix `f4c1a8ac` | clean after 1 fix round |
 | 6 | `POST /games/{id}/reveal-authors` | `f1d65470` | **not yet reviewed** |
 
-**Tasks 5 and 6 have not completed their review gate.** Re-run them before trusting either:
-
-```
-.superpowers/sdd/2026-08-09-anonymous-responses/review-35a922be..8476e704.diff
-```
-
-and generate one for Task 6 with
+**Task 6 has not completed its review gate.** Generate its review package with
 `<skill>/scripts/review-package docs/superpowers/plans/2026-08-09-anonymous-responses.md 8476e704 f1d65470`.
 
 ### Remaining tasks
@@ -99,6 +93,7 @@ All take `AWS_PROFILE=adminaccess node scripts/<name>.js engagetest [--apply]` a
 - **Unawaited async `check()` silently drops assertions.** The plan's test template produced bare `check(...)` calls against an async helper; the process exits before the assertion resolves and the check vanishes from the count with **no failure signal**. Caught empirically in Task 5 (21 call sites, 20 executed). Both test files are now verified clean, but any new test appended to `tests/anonymous-round-flow.js` or `tests/anonymity-contract.js` must `await` every call.
 - **`seedAnonymousRound` seeds no `CONNECTION#` rows.** Any test asserting on a broadcast must `put()` its own connection, or `sent` stays empty and the assertion passes vacuously. Tasks 4, 5 and 6 each add their own inside their own section; the shared helper is deliberately untouched.
 - **`get-answers.js`'s player branch returns no `answers` array at all outside `VOTE#`.** Correct behaviour — players must not see each other's answers during ASK — but it makes any host/player parity check fail if seeded at `ASK`. Pinned by a test so nobody "fixes" it.
+- **`handlePlayerVote` builds `ROUND#` keys unpadded** (`message.js:493,513,524`) — the same defect fixed in the `playerAnswered` branch, left alone because the `VOTE#` branch was out of scope. Worth its own task.
 - **`message.js` routing makes `playerVoted` unreachable.** `isHostMessage` is checked before `isPlayerMessage` and both match a `VOTE#` prefix, so `handlePlayerMessage`'s `playerVoted` branch is dead code. Pre-existing, unrelated to anonymity, worth its own look.
 - **The ballot is positional and stable only by accident** (spec §5.6.5a, risk R1). `submit-vote.js:63` stores `{"0": 1, "1": 2}` and `get-results.js:276` tallies against `answers[index]`; the indices agree only because the answer sort key ends in the author's name. Any re-keying, or an answer arriving mid-round, silently lands votes on the wrong answers. **Independent of anonymity — do not bundle.**
 - **`reopen-round` does not exist** (risk R2). A host who advances early cannot recover.

--- a/docs/handoff/anonymous-responses-2026-08-09.md
+++ b/docs/handoff/anonymous-responses-2026-08-09.md
@@ -1,0 +1,126 @@
+# Handoff — anonymous responses, and the state of everything else
+
+**Date:** 2026-08-09. Everything below is on `dev`, **committed but deliberately NOT pushed** past `85ad6043`. Read the "Do not deploy yet" section before you push anything.
+
+Plan: `docs/superpowers/plans/2026-08-09-anonymous-responses.md`
+Spec: `docs/superpowers/specs/2026-08-08-host-screen-redesign-design.md` §5.6
+SDD ledger: `.superpowers/sdd/2026-08-09-anonymous-responses/progress.md` (git-ignored; per-task briefs, reports and review diffs live beside it)
+
+---
+
+## Test baselines — check before claiming a regression
+
+| Suite | Command | Expected |
+|---|---|---|
+| Backend | `for t in tests/*.js; do node "$t"; done` | **20 suites, 689 passed, 0 failed** |
+| Frontend | `cd src && npx jest __tests__/` | 5 failed suites / 30 failed / 242 passed |
+| Build | `cd src && npm run build` | compiles, 2 pre-existing size warnings |
+| Template | `sam validate --lint -t template-clean.yaml` | valid |
+
+Aggregate backend counts with `grep -E '^[0-9]+ passed'`, **never** `tail -1` — some suites print a trailing line and `tail -1` silently drops them.
+
+The 5 failing frontend suites are stale and out of scope: they predate the auth system (`useAuth must be used within an AuthProvider`) and call `new WebSocketClient()` on a singleton export.
+
+---
+
+## Where anonymous responses got to
+
+**Tasks 1–6 of 11 are done.** The backend can now complete a full round — redact, vote, reveal. Tasks 7–11 are not started.
+
+| # | Task | Commit | Review |
+|---|---|---|---|
+| 1 | Redaction gate, both Lambda dirs | `85ad6043` | clean |
+| 2 | `anonymousUntilReveal` persists through create | `37eae389` | clean |
+| 3 | Redact `GET /games/{id}/answers` | `2c588841` + fix `6de72ea8` | clean after 1 fix round |
+| 4 | Redact `POST /games/{id}/start-vote` | `35a922be` | clean |
+| 5 | Redact the `playerAnswered` socket frame | `8476e704` | **review was still running at handoff** |
+| 6 | `POST /games/{id}/reveal-authors` | `f1d65470` | **not yet reviewed** |
+
+**Tasks 5 and 6 have not completed their review gate.** Re-run them before trusting either:
+
+```
+.superpowers/sdd/2026-08-09-anonymous-responses/review-35a922be..8476e704.diff
+```
+
+and generate one for Task 6 with
+`<skill>/scripts/review-package docs/superpowers/plans/2026-08-09-anonymous-responses.md 8476e704 f1d65470`.
+
+### Remaining tasks
+
+7. **Field Notes must not name an unrevealed author.** `get-ai-summary.js:1175-1176` builds `` `${top.playerName}'s answer, "${top.answer}", earned the most support` `` in code — a deterministic template, not the model. Needs an unattributed fallback while hidden, and the model prompt built from redacted rows.
+8. **The report must honour `AuthorsRevealed`.** `get-results.js:414` persists `Winners` by name, so the report can reconstruct attribution even when the response was redacted. A round never revealed must stay unattributed, or a promise made to the room is broken by an artefact produced after everyone leaves.
+9. **Setup control** — `src/src/config/anonymity.js` + the form. Offered only for formats that hold a vote, derived from `hostRunsVotePhase()` so the two cannot drift.
+10. **Host renders redacted rounds and drives the reveal** — plus hiding standings pre-reveal (attribution by arithmetic) and the `‹ Hide again` display-only step.
+11. **Player ballot** — label by position, mark the player's own row by matching submitted text.
+
+---
+
+## Do not deploy yet
+
+`dev` is **held at `85ad6043`** on the remote. Local `dev` carries Tasks 1–6.
+
+Pushing now would deploy a backend that redacts author names with `anonymousUntilReveal` defaulting **ON for every existing game**, while the host UI has no reveal control (that is Task 10). Names would vanish from the vote and results views with no button to bring them back — recoverable only by calling `POST /games/{id}/reveal-authors` by hand.
+
+**Push `dev` once Task 10 lands**, not before.
+
+This already bit once: `prod` was pushed to `2c588841` mid-feature and had to be force-reset to `85ad6043`. The manual approval gate caught it.
+
+---
+
+## Environment state
+
+| Branch | At | Notes |
+|---|---|---|
+| `main` | `85ad6043` | caught up (was 248 behind). No pipeline attached. |
+| `test` | `85ad6043` | deployed, `engagetest` UPDATE_COMPLETE |
+| `prod` | `85ad6043` | **staged behind the manual approval gate, not yet approved** |
+| `dev` (remote) | `85ad6043` | held — see above |
+
+Prod's pipeline is `Source → ApprovalForProd (Manual) → DeployProd`, so a push stages and waits. `85ad6043` is safe to approve.
+
+**One thing to check after prod deploys:** commit `bdd14fc1` (2026-07-02) enables the API authorizer on admin routes and removes the admin bypass. That is after prod's previous deploy (2025-08-30), so admin access will start depending on real `admins` group membership in Cognito.
+
+`UserPoolV2` landed 2025-08-15, *before* prod's last deploy — so this does **not** replace the pool and existing prod users keep their accounts. An earlier draft of this handoff said otherwise; it was wrong.
+
+### engagetest migrations — one of three applied
+
+**Order matters and the obvious order destroys data.** `cull-ai-prompts` hard-deletes every prompt row with no `promptId` ([cull-ai-prompts.js:192](../../scripts/cull-ai-prompts.js)), which is exactly the 22 `AIPROMPT#GENERATION#*` rows `rekey-generation-prompts` exists to move. Running `cull --apply` first would have destroyed the AI generation prompt library.
+
+- ✅ `rekey-generation-prompts.js engagetest --apply` — **done**, 22 moved, 0 skipped
+- ⬜ `cull-ai-prompts.js engagetest --apply` — verified safe now; post-rekey dry run reports `orphans: 0`, leaving `gameType canonicalised: 8`, `isDefault cleared: 6`
+- ⬜ `migrate-set-versions.js engagetest --apply` — 5 sets, 0 skipped; legacy `SET#<id>` rows stay in place so rollback is `REMOVE activeVersion, versions`
+
+All take `AWS_PROFILE=adminaccess node scripts/<name>.js engagetest [--apply]` and are dry-run by default.
+
+---
+
+## Landmines found while doing this work
+
+- **Unawaited async `check()` silently drops assertions.** The plan's test template produced bare `check(...)` calls against an async helper; the process exits before the assertion resolves and the check vanishes from the count with **no failure signal**. Caught empirically in Task 5 (21 call sites, 20 executed). Both test files are now verified clean, but any new test appended to `tests/anonymous-round-flow.js` or `tests/anonymity-contract.js` must `await` every call.
+- **`seedAnonymousRound` seeds no `CONNECTION#` rows.** Any test asserting on a broadcast must `put()` its own connection, or `sent` stays empty and the assertion passes vacuously. Tasks 4, 5 and 6 each add their own inside their own section; the shared helper is deliberately untouched.
+- **`get-answers.js`'s player branch returns no `answers` array at all outside `VOTE#`.** Correct behaviour — players must not see each other's answers during ASK — but it makes any host/player parity check fail if seeded at `ASK`. Pinned by a test so nobody "fixes" it.
+- **`message.js` routing makes `playerVoted` unreachable.** `isHostMessage` is checked before `isPlayerMessage` and both match a `VOTE#` prefix, so `handlePlayerMessage`'s `playerVoted` branch is dead code. Pre-existing, unrelated to anonymity, worth its own look.
+- **The ballot is positional and stable only by accident** (spec §5.6.5a, risk R1). `submit-vote.js:63` stores `{"0": 1, "1": 2}` and `get-results.js:276` tallies against `answers[index]`; the indices agree only because the answer sort key ends in the author's name. Any re-keying, or an answer arriving mid-round, silently lands votes on the wrong answers. **Independent of anonymity — do not bundle.**
+- **`reopen-round` does not exist** (risk R2). A host who advances early cannot recover.
+
+### Deferred minors
+
+- `schema-compliant-manager.js:100` — comment cites `:264` for the `randomizeQuestions` read; it is now `:274`.
+- `tests/anonymous-round-flow.js` — duplicate section number "5.".
+- No `start-vote` test drives the **not**-hidden branch; covered indirectly elsewhere.
+- `get-answers.js` now makes two extra `GetItem` calls per request regardless of role; in `start-vote.js` they could be issued concurrently with the answers Query to save a round-trip.
+
+---
+
+## The host screen redesign — approved, not started
+
+`docs/design/host-redesign/` — 21 mockups, `audit.js` (168 checks over 21 pages × 4 profiles × 2 viewports), `CRITIQUE.md`, `USER-REVIEWS.md`, `USER-REVIEWS-2.md`. Serve it with a static server on any port and open `index.html`; the type is `vh`-scaled so it only tells the truth full-screen.
+
+Reviewed to approval over four rounds — an independent critic and three simulated first-time evaluators who went from two hard noes to unanimous yes. Plans 2–5 are not written yet:
+
+2. Stage shell + four profile ladders + the `fit()` hook
+3. Console (operator chrome, question browser, how-to-play beat)
+4. Per-state content and the deletions
+5. ENDED, plus two verified defects — `isWaitingState('ENDED')` returns `true` so a finished session renders the lobby, and `setGameState('ENDED')` sits inside the `if (confirmed)` branch of the `gameEnded` dialog so declining strands the game.
+
+Spec §8 carries an implementation order and §7 carries 18 testable negatives, most of which map straight onto `audit.js` checks.

--- a/docs/superpowers/plans/2026-08-09-anonymous-responses.md
+++ b/docs/superpowers/plans/2026-08-09-anonymous-responses.md
@@ -15,6 +15,8 @@ Copied verbatim from `docs/superpowers/specs/2026-08-08-host-screen-redesign-des
 - **Omit, do not null.** A redacted field is *absent* from the payload, never `null`. A client that forgets to handle anonymity then renders nothing rather than the string "null", and the redaction is visible in a payload diff.
 - **Answer order is never changed by redaction.** Order is what the ballot runs on (§5.6.5a). Redact fields; never sort, filter or reindex.
 - **Reveal state is per round, not per game:** `Round.AuthorsRevealed` (boolean, default false). A host may reveal round 3 and end the session before round 4.
+- **Voting closing reveals the round.** *(Owner decision, 2026-08-09, amending Tasks 8 and 10.)* The promise this feature makes is the one already written into the room-facing sentence below — *until voting closes*, not "until the host presses a button". So `AuthorsRevealed` flips automatically when the round enters `RESULTS#nnn`, which is the moment voting closes. From that point names are attributed everywhere: results, Field Notes, standings, the report and the archive export. The report attributes **every** round; there is no unattributed-forever case, because Workie and the host need to see who contributed what. `POST /reveal-authors` survives as a manual override for a host who wants names back *before* closing the vote; it is no longer the only path. The host's on-stage reveal becomes a **display** step over data that already carries names — which is why `‹ Hide again` was always described as display-only and never as a security control.
+- **The gate applies only to formats that hold a vote.** Anonymity is meaningless for trivia (the response is a letter) and wavelength (never attributed on stage), and `hostRunsVotePhase()` already computes exactly that set. Because the flag defaults ON for any game with no recorded preference, a format check inside `isHidden` is what stops every pre-existing trivia and wavelength game from being silently redacted.
 - **The host is inside "nobody".** `role` is a client-supplied query parameter (`get-answers.js:11`), so any payload emitted to a caller claiming `role=host` is emitted to anyone. There is no host-only branch anywhere in this feature.
 - **Default ON.** `anonymousUntilReveal: anonymousUntilReveal !== false`.
 - **Applies only to formats that hold a vote** — call-and-answer, poll, survey. `hostRunsVotePhase()` in `src/src/config/hostControls.js` already computes exactly this set. Trivia and wavelength hide the option entirely rather than showing it disabled.
@@ -1384,132 +1386,268 @@ without ever revealing and the promise has to survive that."
 
 ---
 
-### Task 8: A round never revealed stays unattributed in the report
+### Task 8: Voting closing reveals the round, and the gate only binds voting formats
 
-`get-results.js:414` persists `Winners` by name into the round record, so the report can reconstruct attribution even when the response was redacted. The report must read `AuthorsRevealed`, not simply read what is in the table.
+> **Rewritten 2026-08-09 by owner decision.** The original Task 8 made the report
+> withhold attribution for any round the host never revealed. That is no longer the
+> rule. The promise is *until voting closes* — the exact words already in the
+> room-facing sentence — so closing the vote discharges it, and the report attributes
+> every round. Two defects surface at the same time and belong here because they are
+> the same decision: the gate currently fires for trivia and wavelength, which never
+> opted into anonymity, and nothing flips `AuthorsRevealed` on its own.
+
+Two changes, one test section.
+
+**A. `isHidden` must only bind formats that hold a vote.** The flag defaults ON for any
+game with no recorded preference, and every game created before this feature has no
+`HostPreferences` at all — so today a legacy **trivia** game has its answers redacted
+during ASK, which breaks the host's view of who answered what, and a legacy
+**wavelength** game is redacted for a format that never attributes on stage anyway.
+`hostRunsVotePhase()` in `src/src/config/hostControls.js` already computes the set
+(`trivia` and `wavelength` skip the vote); `isHidden` must agree with it.
+
+**B. Entering `RESULTS#nnn` sets `AuthorsRevealed = true`.** `enterResultsState` in
+`get-results.js:118` is the single choke point for that transition — its own comment
+records that the same update used to be pasted into two branches and missing from two
+others, which is exactly why it was consolidated. Flipping the flag there means it
+cannot be forgotten on the wavelength or zero-vote exits either.
+
+**Consequences, so nobody re-adds them later:**
+- `create-report.js` needs **no** change. The report attributes every round. Do not
+  gate it, do not touch those four line numbers.
+- `get-results.js` needs **no** response redaction. It *is* the vote-close handler, so
+  by the time it assembles a response the round is revealed by definition.
+- `POST /reveal-authors` (Task 6) stays exactly as built. It is now a manual override
+  for a host who wants names back before closing the vote, not the only path.
 
 **Files:**
-- Modify: `lambda-functions/game/get-results.js:323`, `:414`
-- Modify: `lambda-functions/game/create-report.js:278`, `:317`, `:436`, `:441`
-- Test: `tests/anonymous-round-flow.js` (append section 11)
+- Modify: `lambda-functions/game/anonymity.js` **and** `lambda-functions/websocket/anonymity.js` — must stay byte-identical; edit both, or the drift test in `tests/anonymity-contract.js` fails
+- Modify: `lambda-functions/game/get-results.js` — `enterResultsState`
+- Test: `tests/anonymity-contract.js` (append a section), `tests/anonymous-round-flow.js` (append a section)
 
 **Interfaces:**
-- Consumes: `isHidden`, `redactAnswers` from Task 1.
-- Produces: `get-results` omits `playerName` from response tally rows while hidden but still persists scores internally; `create-report` omits attribution for any round whose `AuthorsRevealed` is not true.
+- Consumes: `isHidden` from Task 1; `normalizeGameType` from `lambda-functions/game/game-types.js` (for the agreement test only — see the note in Step 3).
+- Produces: `isHidden(metadata, round)` returns `false` for trivia and wavelength regardless of flag or reveal state; `ROUND#nnn.AuthorsRevealed === true` after the round enters `RESULTS#nnn`.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing tests — the format gate**
 
-Append to `tests/anonymous-round-flow.js`:
+Append a new section to `tests/anonymity-contract.js`, immediately before the final summary. **Every `check(...)` in this file is async — `await` every call you add.** The existing fixtures (`on`, `off`, `bare`) carry no `GameType`, and must keep behaving exactly as they do today: an absent type normalises to `call-and-answer`, which votes, so those tests stay green.
 
 ```js
-console.log('\n11. results and the report');
+console.log('\n7. the gate binds only formats that hold a vote');
+
+const trivia = { GameType: 'trivia', HostPreferences: { anonymousUntilReveal: true } };
+const wavelength = { GameType: 'wavelength', HostPreferences: { anonymousUntilReveal: true } };
+const callAndAnswer = { GameType: 'call-and-answer', HostPreferences: { anonymousUntilReveal: true } };
+
+// Trivia's response is a letter — there is nothing authored to attribute, and
+// redacting it breaks the host's view of who answered what. Wavelength never
+// attributes on the stage. Neither format is ever offered the option, so
+// neither may be caught by a flag that defaults ON.
+await check('trivia is never hidden, even with the flag explicitly on', () =>
+  assert.strictEqual(isHidden(trivia, {}), false));
+await check('wavelength is never hidden, even with the flag explicitly on', () =>
+  assert.strictEqual(isHidden(wavelength, {}), false));
+await check('a voting format with the flag on is still hidden', () =>
+  assert.strictEqual(isHidden(callAndAnswer, {}), true));
+
+// THE CASE THIS TASK EXISTS FOR. Every game created before this feature has no
+// HostPreferences at all, so the default-ON rule caught legacy trivia and
+// wavelength games and silently redacted them.
+await check('a legacy trivia game with no HostPreferences is not hidden', () =>
+  assert.strictEqual(isHidden({ GameType: 'trivia' }, undefined), false));
+await check('a legacy call-and-answer game with no HostPreferences is hidden', () =>
+  assert.strictEqual(isHidden({ GameType: 'call-and-answer' }, undefined), true));
+await check('an absent GameType still defaults to the voting behaviour', () =>
+  assert.strictEqual(isHidden(bare, {}), true));
+
+// Legacy spellings are stored in this table. `quiz` is trivia; a row written
+// under the old spelling must not be redacted either.
+await check('the legacy spelling "quiz" is treated as trivia', () =>
+  assert.strictEqual(isHidden({ GameType: 'quiz' }, {}), false));
+
+// Drift guard, in the spirit of the byte-identical one above. anonymity.js
+// cannot require game-types.js — that module lives only in lambda-functions/game/
+// and anonymity.js must stay byte-identical across both Lambda directories — so
+// the set is inlined there. This asserts the inlined copy still agrees with the
+// canonical vocabulary for every spelling the table can hold.
+const { GAME_TYPE_IDS, ALIASES, normalizeGameType } =
+  require(path.join(REPO, 'lambda-functions/game/game-types.js'));
+
+await check('the inlined skip-set agrees with game-types.js for every spelling', () => {
+  const SKIPS_VOTE = new Set(['trivia', 'wavelength']);
+  for (const spelling of [...GAME_TYPE_IDS, ...Object.keys(ALIASES)]) {
+    const expectedHidden = !SKIPS_VOTE.has(normalizeGameType(spelling));
+    assert.strictEqual(
+      isHidden({ GameType: spelling, HostPreferences: { anonymousUntilReveal: true } }, {}),
+      expectedHidden,
+      `'${spelling}' normalises to '${normalizeGameType(spelling)}' but the gate disagreed`);
+  }
+});
+```
+
+- [ ] **Step 2: Write the failing test — voting closing reveals the round**
+
+Append to `tests/anonymous-round-flow.js` as the **next sequential section number**. Read the end of the file first and continue the numbering — do not assume a number; earlier tasks have already appended sections and a collision makes the output unreadable.
+
+Two hazards, both of which have already cost this project time:
+- `check` is async. **`await` every call.** A bare call exits before its assertion resolves and vanishes from the pass count with no failure signal.
+- `seedAnonymousRound` seeds no `CONNECTION#` rows. `enterResultsState` broadcasts, so `put()` your own connection inside your own section if you assert on `sent` — otherwise the assertion passes vacuously against an empty array. Do not modify the shared helper.
+
+```js
+console.log('\nN. voting closing reveals the round');
 
 const { handler: getResults } = require(path.join(REPO, 'lambda-functions/game/get-results.js'));
 
 seedAnonymousRound('3011');
 put({ PK: 'GAME#3011', SK: 'STATE', State: 'VOTE#001', LessonNumber: 1, CurrentQuestionId: '001' });
 put({ PK: 'GAME#3011', SK: 'QUESTION#001#VOTE#Grace', PlayerName: 'Grace', Votes: { 0: 1 } });
+put({ PK: 'GAME#3011', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+sent = [];
 
-const results = JSON.parse((await getResults({
-  body: JSON.stringify({ gameId: '3011', questionNumber: 1 })
-})).body);
+await getResults({ body: JSON.stringify({ gameId: '3011', questionNumber: 1 }) });
 
-check('tally rows carry no playerName while hidden', () => {
-  const rows = results.results || results.answers || [];
-  assert.ok(rows.every(r => !('playerName' in r)),
-    `leaked in results: ${JSON.stringify(rows[0])}`);
-});
-check('scores are still persisted internally', () =>
-  assert.ok(store.get(key('GAME#3011', 'PLAYER#Ada#SCORE')) !== undefined ||
-            store.get(key('GAME#3011', 'ROUND#001')) !== undefined,
-    'the round record was not written — the reveal would have nothing to join'));
+// The promise is "until voting closes", not "until the host presses a button".
+// Closing the vote is what discharges it.
+await check('entering RESULTS sets AuthorsRevealed on the round', () =>
+  assert.strictEqual(store.get(key('GAME#3011', 'ROUND#001')).AuthorsRevealed, true));
+await check('the round is no longer hidden once results are in', () =>
+  assert.strictEqual(
+    isHidden(store.get(key('GAME#3011', 'METADATA')), store.get(key('GAME#3011', 'ROUND#001'))),
+    false));
 
-console.log('\n12. the report honours AuthorsRevealed');
+// And the ordinary answers endpoint carries names again, with no host action.
+const afterVoteClose = JSON.parse((await askAnswers('3011', 'player')).body);
+await check('GET /answers carries attribution once voting has closed', () =>
+  assert.strictEqual(afterVoteClose.answers[0].playerName, 'Ada'));
 
-const { handler: createReport } = require(path.join(REPO, 'lambda-functions/game/create-report.js'));
+console.log('\nN+1. the round record is written even on the exits that used to skip it');
 
-// Round 1 revealed, round 2 never revealed.
-seedAnonymousRound('3012', { revealed: true });
-put({ PK: 'GAME#3012', SK: 'ROUND#002', QuestionNumber: '002', AuthorsRevealed: false });
-put({ PK: 'GAME#3012', SK: 'QUESTION#002#ANSWER#Ada', PlayerName: 'Ada', Answer: 'round two answer', SubmittedAt: '2026-01-01T00:01:00.000Z' });
+// enterResultsState's own comment records that the state write used to be
+// missing from the wavelength and zero-vote exits. The reveal must not inherit
+// that hole: a round with no votes still closes.
+seedAnonymousRound('3013');
+put({ PK: 'GAME#3013', SK: 'STATE', State: 'VOTE#001', LessonNumber: 1, CurrentQuestionId: '001' });
+put({ PK: 'GAME#3013', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+sent = [];
 
-const report = JSON.parse((await createReport({
-  body: JSON.stringify({ gameId: '3012' })
-})).body);
-const reportText = JSON.stringify(report);
+await getResults({ body: JSON.stringify({ gameId: '3013', questionNumber: 1 }) });
 
-check('a revealed round keeps its attribution in the report', () =>
-  assert.ok(reportText.includes('Ada'), 'the revealed round lost its author'));
-check('an unrevealed round is not attributed in the report', () => {
-  // Find the round-2 section and assert no author on it. A promise made to the
-  // room must not be broken by an artefact produced after everyone leaves.
-  const round2 = (report.rounds || []).find(r => String(r.questionNumber) === '002');
-  assert.ok(round2, 'round 2 missing from the report entirely');
-  assert.ok(!JSON.stringify(round2).includes('Ada'),
-    `unrevealed round attributed in the report: ${JSON.stringify(round2)}`);
-});
+await check('a round that closed with zero votes is still revealed', () =>
+  assert.strictEqual(store.get(key('GAME#3013', 'ROUND#001'))?.AuthorsRevealed, true));
 ```
 
-- [ ] **Step 2: Run it and watch it fail**
+- [ ] **Step 3: Run them and watch them fail**
 
 ```bash
+node tests/anonymity-contract.js
 node tests/anonymous-round-flow.js
 ```
 
-- [ ] **Step 3: Gate `get-results`**
+Expected: the format-gate checks fail (trivia and wavelength are currently hidden), and the reveal checks fail (`AuthorsRevealed` is `undefined` because nothing writes it).
 
-In `lambda-functions/game/get-results.js`, add the require and load the round record alongside the metadata it already reads. Redact `playerName` from the response tally rows built at `:323` while hidden. **Do not change what is persisted** — `Winners` at `:414` and the `PLAYER#{name}#SCORE` writes at `:336-389` stay, because the reveal needs something to join back on and scoring is per-person by design.
+**Verify the failures are real.** A test that cannot fail proves nothing — this plan has already shipped one vacuous assertion. If a new check passes before you have written any implementation, find out why before continuing.
 
-```js
-const { isHidden } = require('./anonymity');
-```
+- [ ] **Step 4: Add the format gate to `isHidden` — in BOTH copies**
 
-At the point the response is assembled:
+In `lambda-functions/game/anonymity.js`, add the skip-set and extend `isHidden`. Then `cp` it over `lambda-functions/websocket/anonymity.js`; the two must stay byte-identical or `tests/anonymity-contract.js` fails.
 
 ```js
-    // Redact the RESPONSE only. The scores and Winners stay in the table —
-    // the reveal has to have something to join back on, and points genuinely
-    // are per-person. What changes is what leaves the building.
-    const hidden = isHidden(metadata, roundRecord);
-    const responseRows = hidden
-      ? rows.map(({ playerName, ...rest }) => rest)
-      : rows;
+/**
+ * Formats whose round never opens a vote.
+ *
+ * INLINED ON PURPOSE. The canonical vocabulary lives in game-types.js, and the
+ * host's runtime answer lives in src/src/config/hostControls.js
+ * (`hostRunsVotePhase`) — but this file must stay byte-identical across
+ * lambda-functions/game/ and lambda-functions/websocket/, and game-types.js
+ * exists only in the former. A require() that resolves in one bundle and not
+ * the other is worse than a duplicated four-element set.
+ * tests/anonymity-contract.js asserts this set still agrees with game-types.js
+ * for every spelling the table can hold, aliases included.
+ */
+const TYPES_THAT_SKIP_VOTE = new Set(['trivia', 'wavelength', 'quiz']);
+
+function skipsVote(gameType) {
+  return TYPES_THAT_SKIP_VOTE.has(String(gameType || '').trim().toLowerCase());
+}
 ```
 
-- [ ] **Step 4: Gate `create-report`**
-
-In `lambda-functions/game/create-report.js`, load each round's `AuthorsRevealed` and omit author fields for any round where it is not `true`. At each of `:278`, `:317`, `:436`, `:441`, guard the attribution with the round's flag:
+and in `isHidden`, before the flag is read:
 
 ```js
-// A round the host never revealed stays unattributed forever. Reading the
-// table directly would reconstruct attribution the room was promised it
-// would not see, in an artefact produced after everyone has left.
-const attributed = round.AuthorsRevealed === true;
+  // Anonymity binds only the formats that hold a vote. Trivia's response is a
+  // letter, so there is nothing authored to attribute — and redacting it breaks
+  // the host's view of who answered what. Wavelength never attributes on stage.
+  //
+  // This check is not cosmetic. The flag defaults ON, and every game created
+  // before this feature has no HostPreferences at all, so without it every
+  // legacy trivia and wavelength game is silently redacted.
+  if (skipsVote(metadata && metadata.GameType)) return false;
 ```
 
-- [ ] **Step 5: Run the tests**
+- [ ] **Step 5: Reveal the round when it enters RESULTS**
+
+In `lambda-functions/game/get-results.js`, inside `enterResultsState` (`:118`), write `AuthorsRevealed` on the round record alongside the state update. Put it *before* `broadcastResultsReady`, so nothing is announced to the room ahead of the record it describes.
+
+```js
+  // VOTING HAS CLOSED, SO THE PROMISE IS DISCHARGED. The room was told "nobody
+  // sees who wrote what — the host included — until voting closes", and this is
+  // that moment. Attribution returns everywhere from here: results, Field Notes,
+  // standings, the report and the archive export.
+  //
+  // It lives in this function rather than at the call sites for the reason the
+  // comment above records — the state write used to be pasted into two branches
+  // and missing from the wavelength and zero-vote exits, so a round could close
+  // without it. The reveal must not inherit that hole.
+  //
+  // Unconditional SET, so it is idempotent: a host who resolves the same round
+  // twice does not error, and POST /reveal-authors having run first is a no-op.
+  await db.send(new UpdateCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: { PK: `GAME#${gameId}`, SK: `ROUND#${paddedQuestionId}` },
+    UpdateExpression: 'SET #revealed = :true, #qn = :qn, #updatedAt = :updatedAt',
+    ExpressionAttributeNames: {
+      '#revealed': 'AuthorsRevealed', '#qn': 'QuestionNumber', '#updatedAt': 'UpdatedAt'
+    },
+    ExpressionAttributeValues: {
+      ':true': true, ':qn': paddedQuestionId, ':updatedAt': new Date().toISOString()
+    }
+  }));
+```
+
+**Do not** add response redaction to `get-results.js`, and **do not** touch `create-report.js`. Both are deliberate: this handler is the vote-close event itself, so by the time it assembles a response the round is revealed by definition, and the report attributes every round.
+
+- [ ] **Step 6: Run the tests**
 
 ```bash
+node tests/anonymity-contract.js
 node tests/anonymous-round-flow.js
 for t in tests/*.js; do node "$t"; done 2>&1 | grep -E '^[0-9]+ passed' | awk '{p+=$1; f+=$3; n++} END {print n" suites, "p" passed, "f" failed"}'
 ```
 
-Expected: 0 failed. `tests/report-payload-flow.js` and `tests/results-state-broadcast.js` must still pass.
+Expected: 0 failed, and the total rises by the number of checks you added. `tests/report-payload-flow.js`, `tests/results-state-broadcast.js` and `tests/trivia-*.js` must still pass — the format gate changes trivia's behaviour back to what those suites expect, so a failure there is a signal, not noise.
 
-- [ ] **Step 6: Commit**
+Aggregate with that `grep`, **never** `tail -1` — some suites print a trailing line and `tail -1` silently drops them.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add lambda-functions/game/get-results.js lambda-functions/game/create-report.js tests/anonymous-round-flow.js
-git commit -m "feat(anonymity): results redaction, and the report honours AuthorsRevealed
+git add lambda-functions/game/anonymity.js lambda-functions/websocket/anonymity.js lambda-functions/game/get-results.js tests/anonymity-contract.js tests/anonymous-round-flow.js
+git commit -m "feat(anonymity): voting closing reveals the round
 
-get-results redacts the response only; Winners and the per-player scores
-stay in the table because the reveal needs something to join back on and
-points genuinely are per-person.
+The promise is the one already written into the room-facing sentence —
+until voting CLOSES, not until the host presses a button. enterResultsState
+is the single choke point for that transition, and its own comment records
+that the state write used to be missing from the wavelength and zero-vote
+exits; putting the reveal there means it cannot inherit that hole.
 
-create-report reads AuthorsRevealed per round rather than reading what is
-in the table, so a round the host never revealed stays unattributed. A
-promise made to the room must not be broken by an artefact produced after
-everyone has left."
+The gate now binds only formats that hold a vote. The flag defaults ON and
+every game created before this feature has no HostPreferences at all, so
+without a format check every legacy trivia game had its answers redacted
+during ASK — which breaks the host's view of who answered what — and every
+legacy wavelength game was redacted for a format that never attributes.
+
+The report is deliberately untouched: it attributes every round."
 ```
 
 ---
@@ -1791,12 +1929,22 @@ export function displayLabelFor(answer, index) {
 
 In `src/src/GameHostPage.jsx`, replace every place the VOTE and RESULTS views print `answer.player` / `answer.playerName` with `displayLabelFor(answer, index)`.
 
-Add the reveal handler:
+Add the reveal handler.
+
+> **Amended 2026-08-09 with Task 8.** `AuthorsRevealed` now flips automatically when
+> the round enters RESULTS, so by the time the host is looking at this screen the
+> payload already carries names and `authorsRevealed` restores as `true`. The on-stage
+> reveal is therefore a **display** step: hold the names back for a beat, then show
+> them. Keep `handleRevealAuthors` anyway — it is the override for a host who wants
+> names back *before* closing the vote, and it is what makes the button correct on a
+> round reopened or resolved out of order. Call it only when `authorsRevealed` is
+> still false; otherwise just flip the local display state.
 
 ```js
-  // The reveal is the primary action of RESULTS, not a consequence of arriving
-  // there — a host cannot forget to reveal because revealing is the only way
-  // forward. See spec §5.6.4.
+  // Display step, plus an override. AuthorsRevealed flips when voting closes
+  // (get-results.js:enterResultsState), so this endpoint is only load-bearing
+  // when the host reveals BEFORE closing the vote. Calling it when the round is
+  // already revealed is a harmless no-op — the endpoint is idempotent.
   const handleRevealAuthors = async () => {
     try {
       const res = await fetch(`${API_BASE}games/${gameId}/reveal-authors`, {

--- a/docs/superpowers/plans/2026-08-09-host-stage-shell.md
+++ b/docs/superpowers/plans/2026-08-09-host-stage-shell.md
@@ -1,0 +1,1378 @@
+# Host Stage Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace both of GameHostPage's current layouts with one fixed-height stage that fits every state on a single screen, at type a room can read, with the four display profiles and the reduction ladder actually working.
+
+**Architecture:** One DOM, one layout, four *literal* CSS ladders declared on the root element (not one ladder times a multiplier — §4.2 records in detail why that could not work). A `.stage` grid of four rows — rail, phase bar, main, dock — where `main` is a two-column grid of content and the room meter. A `fit()` pass searches for the largest presentation that loses nothing, and when nothing fits it sacrifices in a declared order, chrome before content, always.
+
+**Tech Stack:** React 18 (CRA, `src/`), plain CSS in `src/src/styles.css` plus a new stylesheet, Jest + Testing Library (`src/src/__tests__/`), no CSS-in-JS, no build-step additions.
+
+**Spec:** `docs/superpowers/specs/2026-08-08-host-screen-redesign-design.md`. This plan implements §8's steps (1) and (2). Steps (3)–(5) — the Console, per-state content, ENDED — are plans 3–5 and are explicitly out of scope here.
+
+**Approved mockups:** `docs/design/host-redesign/`. These are not sketches — they are audited, running HTML at 168 checks / 0 failures across 21 pages × 4 profiles × 2 viewports, and they are the **source of truth for every CSS value and every line of the fitter**. Where this plan quotes them it quotes them verbatim; where it points at a line range, port that range unchanged rather than retyping it.
+
+## Global Constraints
+
+Copied from the spec. Every task's requirements implicitly include this section.
+
+- **Never render room-facing text below the profile's floor** — 20px Room, 20px Call, 26px TV, 16px Table. Each is the same ~8.3 arcminute target projected through a different distance and pixel density (§4.2), which is why 16px on a laptop is *not* a violation of the 20px number. If content does not fit at the floor, reduce the content, not the type.
+- **A reduction may only fire when space is actually exhausted.** Truncation is something the fitter *does*, never something it inherits from the base stylesheet. Line clamps in base CSS make the fitter blind: content arrives pre-cut, `scrollHeight` equals `clientHeight`, the fitter concludes it fits, and it stops. That produced the worst defect in the project — an 800px box holding 669px of content with five of six options truncated mid-word and 131px sitting empty underneath.
+- **Chrome is sacrificed before content, always.** The meter's column goes at priority −1, ahead of every content group, through the ordered-sacrifice mechanism rather than a special case appended to the end.
+- **Never abbreviate room-facing content.** Type steps down, layout changes, chrome is sacrificed, the meter's column is taken — and only then, if a state still cannot fit, does anything get cut, and that is a budget failure to fix, not a graceful landing.
+- **Never scroll, and never clip silently.** No horizontal scroll anywhere, no vertical scroll on the stage, and no element may lose content to `overflow: hidden` without a *rendering* truncation. **A centred, clipping flex column is banned outright** — it decapitates the top of the content, which is the most important part. Columns are `flex-start` with `margin-block: auto` on the child, so overflow can only ever appear at the bottom.
+- **Never state the same fact twice in one viewport.** One QR, one event title, one progress count, one score list, one round number.
+- **Never name a person on the stage.** Not who has not answered, not who is late. A count is a nudge; a list of names is an attendance record and the room is the wrong audience for one. This binds Table too — Table is a stage profile.
+- **Never print internal vocabulary on the stage.** No feature names, no model nicknames, no panel names.
+- **Never lose the presentation state on reload.** The profile is written to `localStorage` and restored on mount.
+- **The advance control must never be unreachable.** It is a grid row in a fixed-height grid; it cannot be scrolled past, clipped by an ancestor's `overflow: hidden`, or covered by a panel.
+- **Sizes stay in `vh`,** because the binding constraint is vertical fit and `vh` tracks the projected image regardless of the projector's native resolution — one rule correct at 720p, 1080p and 4K.
+- **Do not deploy.** `CLAUDE.md` reserves all deployments to the owner. Never run a deploy script, never push to `test` or `prod`.
+
+## Baselines — verify before claiming a regression
+
+| Suite | Command | Expected at start |
+|---|---|---|
+| Frontend | `cd src && npx jest __tests__/` | 5 failed suites / 30 failed / 242+ passed |
+| Build | `cd src && npm run build` | compiles, 2 pre-existing size warnings |
+| Backend | `for t in tests/*.js; do node "$t"; done` | 20 suites, 0 failed |
+
+The 5 failing frontend suites are stale and out of scope — they predate the auth system (`useAuth must be used within an AuthProvider`) and call `new WebSocketClient()` on a singleton export. **Do not "fix" them.** Confirm the count before and after your task; a sixth failing suite is yours.
+
+Aggregate backend counts with `grep -E '^[0-9]+ passed'`, **not** `tail -1`.
+
+## The testing situation, stated honestly
+
+`docs/design/host-redesign/audit.js` is written to port into component tests unchanged, and §8 says so. **It cannot be ported into Jest as-is.** Every one of its checks is geometric — `getBoundingClientRect`, `scrollHeight`, `getComputedStyle().fontSize` — and jsdom has no layout engine, so all of those return zero. A Jest port of `audit.js` would pass unconditionally and prove nothing, which is exactly the failure mode the spec spends §4.2b warning about.
+
+So this plan splits the guarantee in two:
+
+- **The fitter's *policy*** — the order of sacrifice, the binary search, the floor clamp, which elements may abbreviate — is extracted as pure functions over an injected measurement interface, and is unit-tested exhaustively in Jest. This is where the bugs actually were: `widen()` ordered after the drop loop, the epsilon that made A10 circular, `scrollHeight > clientHeight` asked of every element.
+- **The rendered geometry** stays guarded by `audit.js` against the mockups, which run in a real browser and are already at 0 failures.
+
+Closing the gap — running `audit.js` against the *React* app in a real browser — needs a headless-browser harness this repo does not have. That is real work and it is called out in "Out of scope, recorded" at the end. Do not fake it with jsdom.
+
+## File Structure
+
+**Create:**
+- `src/src/styles/stage.css` — the four ladders, the stage grid, the three regions. New file rather than appending to the 9,654-line `styles.css`, because these rules must be readable as a set.
+- `src/src/config/displayProfile.js` — the profile vocabulary, auto-selection and persistence. Pure; no React.
+- `src/src/hooks/useStageFit.js` — the hook. Owns the DOM and the lifecycle, nothing else.
+- `src/src/hooks/fitPolicy.js` — the fitter's decisions as pure functions over an injected measurer. This is the part that gets tested.
+- `src/src/components/stage/Stage.jsx` — the grid and the profile class.
+- `src/src/components/stage/Rail.jsx` — phase chip, title, round context, join line, optional timer.
+- `src/src/components/stage/PhaseBar.jsx` — the full-width phase band.
+- `src/src/components/stage/RoomMeter.jsx` — one region, one question: where is the room.
+- `src/src/components/stage/Dock.jsx` — the bottom grid row. Wraps the existing `HostActionBar`.
+- `src/src/__tests__/displayProfile.test.js`
+- `src/src/__tests__/fitPolicy.test.js`
+- `src/src/__tests__/stageShell.test.jsx`
+
+**Modify:**
+- `src/src/GameHostPage.jsx` — render the shell; delete the two old layouts and the listed dead code
+- `src/src/index.css` or wherever global stylesheets are imported — import `styles/stage.css`
+- `src/src/config/hostControls.js` — two additions only (§5.3); its decision logic is unchanged
+
+**Do not modify:** `src/src/config/hostRemote.js`, `src/src/config/instructions.js`, `src/src/config/gameTypes.js`, `src/src/components/HostActionBar.jsx`'s keyboard handling / typing-target guard / disabled-hint behaviour. The spec names these as the best-reasoned files in the area. `HostActionBar`'s positioning CSS is the only part that changes.
+
+---
+
+### Task 1: The four display profiles
+
+The parameter every later task reads. Pure logic plus a stylesheet; no components yet.
+
+**Files:**
+- Create: `src/src/config/displayProfile.js`
+- Create: `src/src/styles/stage.css`
+- Test: `src/src/__tests__/displayProfile.test.js`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `PROFILES` → `['room', 'tv', 'call', 'table']`
+  - `DEFAULT_PROFILE` → `'room'`
+  - `profileClass(profile)` → `'d-room' | 'd-tv' | 'd-call' | 'd-table'`
+  - `autoProfile(viewportWidth)` → `'table'` below 1600, `'room'` at or above
+  - `loadProfile(storage, viewportWidth)` → the persisted profile if valid, else `autoProfile(...)`
+  - `saveProfile(storage, profile)` → writes; ignores a throwing storage
+  - `FLOORS` → `{ room: 20, tv: 26, call: 20, table: 16 }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/src/__tests__/displayProfile.test.js`:
+
+```js
+/**
+ * The display profile is the one parameter the whole stage reads, and it has
+ * failed silently before: revision 1 scaled one ladder by a `--k` multiplier
+ * declared on :root, where it substituted against :root's own value of 1, so
+ * all three profiles rendered identically and only the boxes shrank. The audit
+ * check that catches that (A5) lives in a browser; what CAN be tested here is
+ * that the selection and persistence rules are right, because "never lose the
+ * presentation state on reload" is a hard requirement and a projector browser
+ * that reloads has to come back exactly as it was.
+ */
+import {
+  PROFILES, DEFAULT_PROFILE, FLOORS,
+  profileClass, autoProfile, loadProfile, saveProfile,
+} from '../config/displayProfile';
+
+/** A localStorage stand-in. jsdom provides one, but an explicit fake keeps
+ *  these tests independent of jsdom's global state leaking between files. */
+function fakeStorage(initial = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => { map.set(k, String(v)); },
+    removeItem: (k) => { map.delete(k); },
+    _map: map,
+  };
+}
+
+describe('the profile vocabulary', () => {
+  test('there are exactly four, and Room is the default', () => {
+    expect(PROFILES).toEqual(['room', 'tv', 'call', 'table']);
+    expect(DEFAULT_PROFILE).toBe('room');
+  });
+
+  test('each profile maps to its root class', () => {
+    expect(profileClass('room')).toBe('d-room');
+    expect(profileClass('tv')).toBe('d-tv');
+    expect(profileClass('call')).toBe('d-call');
+    expect(profileClass('table')).toBe('d-table');
+  });
+
+  test('an unknown profile falls back to the default class rather than throwing', () => {
+    expect(profileClass('projector')).toBe('d-room');
+    expect(profileClass(undefined)).toBe('d-room');
+  });
+
+  // The floors are angular targets projected through a distance and a pixel
+  // density, not a style preference. They are asserted here so a later "tidy
+  // up" cannot quietly unify them.
+  test('each profile carries its own floor', () => {
+    expect(FLOORS).toEqual({ room: 20, tv: 26, call: 20, table: 16 });
+  });
+});
+
+describe('automatic selection', () => {
+  // TV and Call cannot be detected — the browser cannot know a panel's physical
+  // size, and it cannot know it is being screen-shared. Only Table is
+  // detectable, and only by the crude proxy of viewport width.
+  test('below 1600px is Table', () => {
+    expect(autoProfile(1440)).toBe('table');
+    expect(autoProfile(1599)).toBe('table');
+  });
+
+  test('1600px and above is Room', () => {
+    expect(autoProfile(1600)).toBe('room');
+    expect(autoProfile(1920)).toBe('room');
+  });
+
+  test('a missing width does not crash and lands on the default', () => {
+    expect(autoProfile(undefined)).toBe('room');
+  });
+});
+
+describe('persistence', () => {
+  test('a persisted profile wins over auto-selection', () => {
+    // The whole point: a host on a 1366px laptop who chose TV meant it.
+    expect(loadProfile(fakeStorage({ 'engage.displayProfile': 'tv' }), 1366)).toBe('tv');
+  });
+
+  test('nothing persisted falls back to auto-selection', () => {
+    expect(loadProfile(fakeStorage(), 1366)).toBe('table');
+    expect(loadProfile(fakeStorage(), 1920)).toBe('room');
+  });
+
+  test('a junk value is ignored rather than trusted', () => {
+    expect(loadProfile(fakeStorage({ 'engage.displayProfile': 'banana' }), 1920)).toBe('room');
+  });
+
+  test('saving round-trips', () => {
+    const s = fakeStorage();
+    saveProfile(s, 'call');
+    expect(loadProfile(s, 1920)).toBe('call');
+  });
+
+  test('an unknown profile is never saved', () => {
+    const s = fakeStorage();
+    saveProfile(s, 'banana');
+    expect(s.getItem('engage.displayProfile')).toBeNull();
+  });
+
+  // Safari in private mode throws on setItem. Losing the preference is
+  // survivable; a white screen in front of a room is not.
+  test('a throwing storage does not propagate', () => {
+    const hostile = {
+      getItem: () => { throw new Error('denied'); },
+      setItem: () => { throw new Error('denied'); },
+    };
+    expect(() => saveProfile(hostile, 'tv')).not.toThrow();
+    expect(loadProfile(hostile, 1920)).toBe('room');
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd src && npx jest __tests__/displayProfile.test.js
+```
+
+Expected: `Cannot find module '../config/displayProfile'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `src/src/config/displayProfile.js`:
+
+```js
+/**
+ * Which display the stage is being shown on.
+ *
+ * There are four profiles and they are four LITERAL ladders, not one ladder
+ * times a scalar. Revision 1 of the design tried the scalar and it failed three
+ * separate ways; the third is the one that matters — a multiplier can only
+ * honour one floor, and the four contexts have four different ones, each
+ * derived from the same ~8.3 arcminute label target through a different
+ * viewing distance and pixel density:
+ *
+ *   Room   projected >=90in, <=30ft, ~20ppi   -> 20px
+ *   TV     ~65in panel,      <=20ft, ~30ppi   -> 26px
+ *   Call   screen-share; the ENCODER is the constraint, not the eye, so it
+ *          keeps Room's ladder and changes treatment only  -> 20px
+ *   Table  laptop, 2-4ft, ~120ppi             -> 16px
+ *
+ * Table's 16px is not a violation of the 20px rule. At ~120ppi and three feet
+ * it subtends 9.0 arcminutes — MORE than the 20px Room floor buys at 25 feet.
+ * Holding 20px there would spend space to over-serve an eye eight times closer.
+ */
+
+export const PROFILES = ['room', 'tv', 'call', 'table'];
+export const DEFAULT_PROFILE = 'room';
+
+/** Angular floors, expressed in pixels for the display each was derived for. */
+export const FLOORS = { room: 20, tv: 26, call: 20, table: 16 };
+
+const STORAGE_KEY = 'engage.displayProfile';
+
+/** Width below which a browser is assumed to be a laptop panel, not a stage. */
+const TABLE_MAX_WIDTH = 1600;
+
+function isProfile(value) {
+  return PROFILES.indexOf(value) !== -1;
+}
+
+/** The root class carrying this profile's ladder. */
+export function profileClass(profile) {
+  return `d-${isProfile(profile) ? profile : DEFAULT_PROFILE}`;
+}
+
+/**
+ * The only profile a browser can infer.
+ *
+ * TV and Call are undetectable in principle — nothing in the platform reports a
+ * panel's physical size, and nothing reports that the surface is being
+ * re-encoded into a video call. Both are explicit choices in the Console.
+ */
+export function autoProfile(viewportWidth) {
+  if (typeof viewportWidth !== 'number' || !isFinite(viewportWidth)) return DEFAULT_PROFILE;
+  return viewportWidth < TABLE_MAX_WIDTH ? 'table' : DEFAULT_PROFILE;
+}
+
+/**
+ * The profile to mount with.
+ *
+ * A stored choice always wins: a host on a 1366px laptop who picked TV meant
+ * it, and "never lose the presentation state on reload" is a hard requirement —
+ * a projector browser that reloads must come back exactly as it was. This is
+ * why `useEffect(() => setBigScreenMode(false), [])` has to be deleted rather
+ * than adapted.
+ */
+export function loadProfile(storage, viewportWidth) {
+  let stored = null;
+  try {
+    stored = storage && storage.getItem(STORAGE_KEY);
+  } catch (e) {
+    // Private-mode Safari throws on access. Losing the preference is
+    // survivable; a blank stage in front of a room is not.
+    stored = null;
+  }
+  return isProfile(stored) ? stored : autoProfile(viewportWidth);
+}
+
+export function saveProfile(storage, profile) {
+  if (!isProfile(profile)) return;
+  try {
+    storage && storage.setItem(STORAGE_KEY, profile);
+  } catch (e) {
+    /* see loadProfile */
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd src && npx jest __tests__/displayProfile.test.js
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Create the stylesheet**
+
+Create `src/src/styles/stage.css`. Port the following ranges from `docs/design/host-redesign/02-ask-call-and-answer.html` **verbatim** — they are the audited values and retyping them is how a digit gets lost:
+
+- lines **63–106** — the four root ladders
+- lines **108–117** — the `body` chrome tokens
+- lines **122–131** — the `.stage` grid
+- lines **133–144** — the `.field` treatment, including the two `:root.d-call` overrides
+
+The four ladders are reproduced here so a reviewer can check the port without opening the mockup:
+
+```css
+:root, :root.d-room{
+  --L-hero:      clamp(56px, 8.4vh, 104px);
+  --L-primary:   clamp(40px, 5.6vh,  68px);
+  --L-secondary: clamp(28px, 3.7vh,  44px);
+  --L-body:      clamp(22px, 2.8vh,  34px);
+  --L-meta:      clamp(20px, 1.9vh,  24px);
+  --floor:20px; --measure-base:26ch; --bar-h:8px; --fit-min:.55;
+  --dock-h:calc(9vh + 4vh);
+}
+:root.d-tv{
+  --L-hero:      clamp(72px, 11vh, 132px);
+  --L-primary:   clamp(52px, 7.4vh, 88px);
+  --L-secondary: clamp(36px, 4.8vh, 56px);
+  --L-body:      clamp(28px, 3.5vh, 42px);
+  --L-meta:      clamp(26px, 2.4vh, 31px);
+  /* TV may not scale below Room's rendered size — see minFit() in the fitter.
+     56 x .78 = 43.7px, which is Room's 44px secondary tier. Below that it
+     must drop something instead of shrinking. */
+  --floor:26px; --measure-base:22ch; --bar-h:12px; --fit-min:.78;
+  --dock-h:calc(11vh + 4vh);
+}
+:root.d-call{
+  --L-hero:      clamp(56px, 8.4vh, 104px);
+  --L-primary:   clamp(40px, 5.6vh,  68px);
+  --L-secondary: clamp(28px, 3.7vh,  44px);
+  --L-body:      clamp(22px, 2.8vh,  34px);
+  --L-meta:      clamp(20px, 1.9vh,  24px);
+  /* Measure matches Room exactly. A tighter measure wraps more, which makes
+     the fitter scale down, which silently defeated the stated intent that Call
+     keeps Room's type — measured ~6% below Room on every dense state. Call
+     differs by field and hairline, not by size. */
+  --floor:20px; --measure-base:26ch; --bar-h:10px; --fit-min:.55;
+  --hair:2px;                         /* 1px rules do not survive a video codec */
+  --dock-h:calc(9vh + 4vh);
+}
+:root.d-table{
+  --L-hero:      clamp(44px, 6.2vh, 64px);
+  --L-primary:   clamp(32px, 4.0vh, 44px);
+  --L-secondary: clamp(22px, 2.6vh, 30px);
+  --L-body:      clamp(18px, 2.0vh, 24px);
+  --L-meta:      clamp(16px, 1.5vh, 19px);
+  --floor:16px; --measure-base:30ch; --bar-h:5px; --fit-min:.55;
+  --dock-h:calc(8vh + 3.5vh);
+}
+```
+
+And the scaled content tiers, which are the mechanism the floor is enforced by — every scaled value wrapped in `max(var(--floor), …)` so the search can only shrink type as far as the floor and must then find a different lever:
+
+```css
+.content{ --fit:1; }
+.content{
+  --t-hero:max(var(--floor),calc(var(--L-hero) * var(--fit)));
+  --t-primary:max(var(--floor),calc(var(--L-primary) * var(--fit)));
+  --t-secondary:max(var(--floor),calc(var(--L-secondary) * var(--fit)));
+  --t-body:max(var(--floor),calc(var(--L-body) * var(--fit)));
+  /* Label and meta tiers do NOT scale. */
+  --measure:calc(var(--measure-base) + (1 - var(--fit)) * 30ch);
+}
+```
+
+Two rules that must be written by hand because they are the invariant, not a value:
+
+```css
+/* NEVER CENTRE A CLIPPING BOX. `justify-content: center` with `overflow:
+   hidden` overflows BOTH ends and clips both — so the top of the question is
+   the first thing to disappear, with no scrollbar and no out-of-bounds rect to
+   detect it by. `flex-start` plus `margin-block: auto` on the child absorbs
+   spare space (short content still centres) but never goes negative, so
+   overflow can only ever appear at the bottom. Losing the tail of a list is
+   survivable; losing the head of the question is not. */
+.content{ display:flex; flex-direction:column; justify-content:flex-start; overflow:hidden; }
+.content > .fitbox{ margin-block:auto; }
+
+/* NO LINE CLAMPS LIVE HERE. Truncation is something the fitter DOES, after
+   exhausting every other lever — never something the base stylesheet applies in
+   advance. A clamp in base CSS makes the fitter blind: content arrives already
+   cut, scrollHeight equals clientHeight, the fitter concludes it fits and
+   stops. That shipped an 800px box holding 669px of content with five of six
+   options truncated mid-word and 131px empty underneath. Clamps belong behind
+   [data-clamped="on"] and nowhere else. */
+.content[data-clamped="on"] .opt .txt{ -webkit-line-clamp:2; display:-webkit-box; -webkit-box-orient:vertical; overflow:hidden; }
+```
+
+Import it once, beside the existing global stylesheet import.
+
+- [ ] **Step 6: Verify the build**
+
+```bash
+cd src && npm run build
+```
+
+Expected: compiles, 2 pre-existing size warnings, no new ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/src/config/displayProfile.js src/src/styles/stage.css src/src/__tests__/displayProfile.test.js
+git commit -m "feat(stage): the four display profiles, as four literal ladders
+
+Four ladders declared on the root element, not one ladder times a scalar.
+The scalar was tried and failed three ways; the one that matters is that a
+multiplier can only honour one floor and the four contexts have four,
+each derived from the same ~8.3 arcminute target through a different
+distance and pixel density.
+
+Table's 16px floor is not a violation of the 20px rule: at ~120ppi and
+three feet it subtends 9.0 arcminutes, more than 20px buys at 25 feet.
+
+The profile persists. A projector browser that reloads must come back
+exactly as it was."
+```
+
+---
+
+### Task 2: The fitter's policy, as pure functions
+
+The part that has actually broken, extracted so it can be tested without a layout engine. No DOM here — every measurement arrives through an injected interface.
+
+**Files:**
+- Create: `src/src/hooks/fitPolicy.js`
+- Test: `src/src/__tests__/fitPolicy.test.js`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `searchScale({ min, max, iterations, isClean, setScale })` → `number | null` — the largest clean scale, or `null` if even `min` is dirty
+  - `buildSacrificeList({ hasMeter, isSolo, dropGroups })` → ordered array of `{ order, kind: 'meter' | 'group', el?, note? }`
+  - `declaresTruncation(computedStyle)` → boolean
+  - `isAbbreviated(computedStyle, { scrollHeight, clientHeight, scrollWidth, clientWidth })` → boolean
+  - `ITERATIONS` → `7`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/src/__tests__/fitPolicy.test.js`:
+
+```js
+/**
+ * The fitter's decisions, with the measuring taken away.
+ *
+ * jsdom has no layout engine, so every geometric assertion in
+ * docs/design/host-redesign/audit.js returns zero here and would pass
+ * unconditionally. What CAN be tested — and what actually broke in three
+ * separate rounds of review — is the policy: the order things are sacrificed
+ * in, the shape of the search, and which elements are even allowed to
+ * abbreviate. All three shipped wrong at least once.
+ */
+import {
+  ITERATIONS, searchScale, buildSacrificeList,
+  declaresTruncation, isAbbreviated,
+} from '../hooks/fitPolicy';
+
+describe('the scale search', () => {
+  /** A box that is clean at or below `threshold`. Monotonic, like the real one. */
+  function boxCleanBelow(threshold) {
+    let scale = 1;
+    return {
+      setScale: (v) => { scale = v; },
+      isClean: () => scale <= threshold,
+      get scale() { return scale; },
+    };
+  }
+
+  test('a state that fits at full size is left at full size', () => {
+    const box = boxCleanBelow(1);
+    expect(searchScale({ min: 0.55, max: 1, isClean: box.isClean, setScale: box.setScale }))
+      .toBe(1);
+  });
+
+  test('a state that fits nowhere in range returns null rather than a wrong answer', () => {
+    const box = boxCleanBelow(0.4); // below the floor
+    expect(searchScale({ min: 0.55, max: 1, isClean: box.isClean, setScale: box.setScale }))
+      .toBeNull();
+  });
+
+  test('it converges from below, never returning a scale that is not clean', () => {
+    const box = boxCleanBelow(0.8);
+    const found = searchScale({ min: 0.55, max: 1, isClean: box.isClean, setScale: box.setScale });
+    expect(found).toBeLessThanOrEqual(0.8);
+    // Seven halvings of a 0.45-wide interval resolves to ~0.0035.
+    expect(found).toBeGreaterThan(0.8 - 0.01);
+  });
+
+  test('it leaves the box AT the scale it returns, not at the last one it probed', () => {
+    // This is the bug shape: a binary search that reports a good value but
+    // leaves the element rendering at whatever the final probe set.
+    const box = boxCleanBelow(0.8);
+    const found = searchScale({ min: 0.55, max: 1, isClean: box.isClean, setScale: box.setScale });
+    expect(box.scale).toBe(found);
+  });
+
+  test('the search is exactly seven iterations — a resolution, not a guess', () => {
+    let probes = 0;
+    const box = boxCleanBelow(0.8);
+    searchScale({
+      min: 0.55, max: 1,
+      isClean: () => { probes += 1; return box.isClean(); },
+      setScale: box.setScale,
+    });
+    // max probe + min probe + ITERATIONS midpoints.
+    expect(probes).toBe(ITERATIONS + 2);
+  });
+
+  // data-grow: a state carrying one object — a wavelength subject, a champion,
+  // a join code — may exceed the ladder. The ladder is a legibility FLOOR
+  // derived from the room, not a ceiling, and a ladder tuned for a dense screen
+  // under-uses a sparse one.
+  test('a growable state may exceed 1', () => {
+    const box = boxCleanBelow(2);
+    expect(searchScale({ min: 0.55, max: 2.2, isClean: box.isClean, setScale: box.setScale }))
+      .toBe(2.2);
+  });
+});
+
+describe('the order of sacrifice', () => {
+  const groups = [
+    { el: 'pager', order: 1, note: null },
+    { el: 'guarantee', order: 2, note: null },
+    { el: 'third-answer', order: 3, note: 'Answers 3+' },
+  ];
+
+  // THE BUG THIS TEST EXISTS FOR. widen() used to run only AFTER every
+  // data-drop group had been hidden, so a state discarded an ANSWER and then
+  // kept a 233px standings column. Measured on 21-results-revealed at
+  // 1280x720: two cards, meter kept, 117px unused, second place thrown away —
+  // on the reveal beat, the payoff of the entire anonymity feature.
+  test('the meter goes before any content group', () => {
+    const list = buildSacrificeList({ hasMeter: true, isSolo: false, dropGroups: groups });
+    expect(list[0].kind).toBe('meter');
+    expect(list[0].order).toBe(-1);
+  });
+
+  test('groups follow in ascending declared order', () => {
+    const list = buildSacrificeList({ hasMeter: true, isSolo: false, dropGroups: groups });
+    expect(list.slice(1).map((e) => e.el)).toEqual(['pager', 'guarantee', 'third-answer']);
+  });
+
+  test('declaration order does not matter — only the number does', () => {
+    const shuffled = [groups[2], groups[0], groups[1]];
+    const list = buildSacrificeList({ hasMeter: true, isSolo: false, dropGroups: shuffled });
+    expect(list.slice(1).map((e) => e.el)).toEqual(['pager', 'guarantee', 'third-answer']);
+  });
+
+  test('a state already solo does not offer the meter twice', () => {
+    const list = buildSacrificeList({ hasMeter: true, isSolo: true, dropGroups: groups });
+    expect(list.some((e) => e.kind === 'meter')).toBe(false);
+  });
+
+  test('a state with no meter still sacrifices its groups', () => {
+    const list = buildSacrificeList({ hasMeter: false, isSolo: false, dropGroups: groups });
+    expect(list.map((e) => e.kind)).toEqual(['group', 'group', 'group']);
+  });
+
+  test('an empty state has nothing to give up', () => {
+    expect(buildSacrificeList({ hasMeter: false, isSolo: false, dropGroups: [] })).toEqual([]);
+  });
+});
+
+describe('which elements may abbreviate at all', () => {
+  const base = { webkitLineClamp: 'none', textOverflow: 'clip', whiteSpace: 'normal' };
+
+  test('a line clamp declares a truncation', () => {
+    expect(declaresTruncation({ ...base, webkitLineClamp: '2' })).toBe(true);
+  });
+
+  test('ellipsis plus nowrap declares a truncation', () => {
+    expect(declaresTruncation({ ...base, textOverflow: 'ellipsis', whiteSpace: 'nowrap' })).toBe(true);
+  });
+
+  // text-overflow only applies to a block container with inline content. On a
+  // flex box it is inert — which is exactly how the rail shipped clipping
+  // mid-glyph with no ellipsis, at -445px of slack.
+  test('ellipsis without nowrap declares nothing, because it cannot render', () => {
+    expect(declaresTruncation({ ...base, textOverflow: 'ellipsis', whiteSpace: 'normal' })).toBe(false);
+  });
+
+  test('ordinary text declares nothing — it just wraps and makes its parent taller', () => {
+    expect(declaresTruncation(base)).toBe(false);
+  });
+});
+
+describe('detecting an actual abbreviation', () => {
+  const clamped = { webkitLineClamp: '2', textOverflow: 'clip', whiteSpace: 'normal', lineHeight: '34.9272px', fontSize: '33.264px' };
+
+  // THE OTHER BUG THIS EXISTS FOR. A block with a fractional line-height
+  // reports a pixel of phantom overflow — measured, h1.q reported scrollHeight
+  // 176 against clientHeight 175 — which made a naive predicate permanently
+  // true, drove the search to its floor, and left 548px of a 795px box empty.
+  test('one pixel of phantom overflow is not an abbreviation', () => {
+    expect(isAbbreviated(clamped, { scrollHeight: 176, clientHeight: 175, scrollWidth: 0, clientWidth: 0 }))
+      .toBe(false);
+  });
+
+  test('half a line of tolerance, and beyond it a real cut', () => {
+    // Half of 34.93 is ~17.5. 190 - 175 = 15 is inside; 200 - 175 = 25 is not.
+    expect(isAbbreviated(clamped, { scrollHeight: 190, clientHeight: 175, scrollWidth: 0, clientWidth: 0 }))
+      .toBe(false);
+    expect(isAbbreviated(clamped, { scrollHeight: 200, clientHeight: 175, scrollWidth: 0, clientWidth: 0 }))
+      .toBe(true);
+  });
+
+  test('a horizontal cut counts, with a tighter tolerance', () => {
+    expect(isAbbreviated(clamped, { scrollHeight: 0, clientHeight: 0, scrollWidth: 300, clientWidth: 200 }))
+      .toBe(true);
+  });
+
+  test('an element that declares no truncation can never be abbreviated', () => {
+    const plain = { webkitLineClamp: 'none', textOverflow: 'clip', whiteSpace: 'normal', lineHeight: '20px', fontSize: '16px' };
+    expect(isAbbreviated(plain, { scrollHeight: 9999, clientHeight: 10, scrollWidth: 0, clientWidth: 0 }))
+      .toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd src && npx jest __tests__/fitPolicy.test.js
+```
+
+Expected: `Cannot find module '../hooks/fitPolicy'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `src/src/hooks/fitPolicy.js`:
+
+```js
+/**
+ * The fitter's decisions, with the measuring taken out.
+ *
+ * The rule, stated once: A REDUCTION MAY ONLY FIRE WHEN SPACE IS ACTUALLY
+ * EXHAUSTED.
+ *
+ * Order of preference, cheapest loss first:
+ *   1. full size, no loss
+ *   2. smaller type, no loss          (continuous, floored scale search)
+ *   3. different layout, no loss      (option grid column count)
+ *   4. drop CHROME                    (the meter, then data-drop groups)
+ *   5. clamp                          (terminal; a budget failure, not a landing)
+ *
+ * Everything here is pure so it can be tested without a layout engine. The DOM
+ * half lives in useStageFit.js and does nothing but measure and apply.
+ */
+
+/** Halvings of the scale interval. Seven resolves 0.45 to about 0.0035. */
+export const ITERATIONS = 7;
+
+/**
+ * Largest scale in [min, max] that satisfies isClean().
+ *
+ * Monotonic — a smaller scale is never worse — so a binary search is exact to
+ * its resolution. Returns null when even `min` is dirty, which is the signal
+ * to reach for a different lever rather than to keep shrinking: below the floor
+ * the search simply stops working, and that is the property that makes this not
+ * the unfloored "auto-shrink to fit" the design rejects.
+ *
+ * Leaves the box AT the returned scale.
+ */
+export function searchScale({ min, max, iterations = ITERATIONS, isClean, setScale }) {
+  setScale(max);
+  if (isClean()) return max;
+
+  setScale(min);
+  if (!isClean()) return null;
+
+  let lo = min;
+  let hi = max;
+  let best = min;
+  for (let i = 0; i < iterations; i += 1) {
+    const mid = (lo + hi) / 2;
+    setScale(mid);
+    if (isClean()) { best = mid; lo = mid; } else { hi = mid; }
+  }
+  setScale(best);
+  return best;
+}
+
+/**
+ * Everything this state is willing to give up, cheapest first.
+ *
+ * CHROME BEFORE CONTENT, ALWAYS. The meter enters at priority -1, ahead of
+ * every content group, through the same mechanism as everything else rather
+ * than as a special case bolted to the end — which is what it was, and which
+ * made a results state throw away an answer while keeping a 233px standings
+ * column.
+ *
+ * Width is the cheapest lever on the stage: a wider measure means fewer lines,
+ * which buys height at no cost to type size and no cost to content.
+ */
+export function buildSacrificeList({ hasMeter, isSolo, dropGroups }) {
+  const list = [];
+  if (hasMeter && !isSolo) list.push({ order: -1, kind: 'meter' });
+  (dropGroups || []).forEach((g) => {
+    list.push({ order: g.order, kind: 'group', el: g.el, note: g.note || null });
+  });
+  return list.sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Does this element DECLARE a truncation that renders?
+ *
+ * Only clamped or ellipsised elements can abbreviate anything; ordinary text
+ * wraps and makes its parent taller, which the overflow check already sees.
+ * And `text-overflow` only applies to a block container with inline content —
+ * on a flex container it is inert, which is how the rail shipped clipping
+ * mid-glyph with no ellipsis at all.
+ */
+export function declaresTruncation(cs) {
+  if (!cs) return false;
+  const clamp = cs.webkitLineClamp;
+  if (clamp && clamp !== 'none' && clamp !== '') return true;
+  return cs.textOverflow === 'ellipsis' && /nowrap|pre$/.test(cs.whiteSpace || '');
+}
+
+/**
+ * Has this element actually lost content?
+ *
+ * Asking every element whether scrollHeight exceeds clientHeight is not a
+ * stricter version of this question, it is a different and wrong one: a block
+ * with a fractional line-height reports a pixel of phantom overflow — measured,
+ * 176 against 175 — which makes the predicate permanently true, drives the
+ * search to its floor, and leaves 548px of a 795px box empty. Ask only the
+ * elements that can actually lie, with a tolerance of half a line.
+ */
+export function isAbbreviated(cs, rect) {
+  if (!declaresTruncation(cs)) return false;
+  const lineHeight = parseFloat(cs.lineHeight) || parseFloat(cs.fontSize) * 1.2 || 0;
+  const tolerance = Math.max(2, lineHeight * 0.5);
+  if (rect.scrollHeight > rect.clientHeight + tolerance) return true;
+  return rect.scrollWidth > rect.clientWidth + 2;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd src && npx jest __tests__/fitPolicy.test.js
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/src/hooks/fitPolicy.js src/src/__tests__/fitPolicy.test.js
+git commit -m "feat(stage): the fitter's policy, extracted and tested
+
+jsdom has no layout engine, so every geometric check in audit.js returns
+zero there and would pass unconditionally. The policy is what actually
+broke — three times — so it is extracted and tested instead: the meter
+sacrificed before content rather than after it, a search that leaves the
+box at the scale it reports, and a truncation predicate asked only of
+elements that can actually lie.
+
+That last one is the sub-pixel trap: a block with a fractional
+line-height reports 176 against 175, which made a naive predicate
+permanently true and left 548px of a 795px box empty."
+```
+
+---
+
+### Task 3: The `useStageFit` hook
+
+The DOM half. About forty lines of measuring and applying, wrapped around Task 2's decisions. It belongs in a hook, not in `GameHostPage`.
+
+**Files:**
+- Create: `src/src/hooks/useStageFit.js`
+- Test: `src/src/__tests__/stageShell.test.jsx` (create; the hook's observable contract only)
+
+**Interfaces:**
+- Consumes: everything `fitPolicy.js` exports.
+- Produces: `useStageFit(stageRef, deps)` → `void`. Runs on mount, on resize, and whenever `deps` change. Idempotent.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/src/__tests__/stageShell.test.jsx`:
+
+```jsx
+/**
+ * What can honestly be asserted about the hook in jsdom.
+ *
+ * Not the geometry — jsdom reports every box as zero-sized, so a "does it fit"
+ * assertion here would be a lie. What IS real: the hook must be idempotent
+ * (it is called on every render in practice), it must reset drop state before
+ * measuring rather than accumulating it, and it must not leak listeners.
+ * Those are lifecycle properties, and lifecycle is exactly what jsdom models
+ * correctly.
+ */
+import React, { useRef } from 'react';
+import { render, act } from '@testing-library/react';
+import useStageFit from '../hooks/useStageFit';
+
+function Harness({ deps = [] }) {
+  const ref = useRef(null);
+  useStageFit(ref, deps);
+  return (
+    <div ref={ref} className="stage">
+      <div className="content">
+        <div className="fitbox">
+          <h1 className="q">A question</h1>
+          <p className="qdetail" data-drop="1" data-drop-note="Full prompt">Detail</p>
+        </div>
+        <p className="reduced" hidden />
+      </div>
+    </div>
+  );
+}
+
+describe('useStageFit lifecycle', () => {
+  test('it mounts without throwing in a zero-sized document', () => {
+    expect(() => render(<Harness />)).not.toThrow();
+  });
+
+  test('a state that fits leaves no reduction applied', () => {
+    // Every box is 0x0 in jsdom, so nothing overflows and nothing should be
+    // sacrificed. A hook that drops groups here is dropping them unconditionally.
+    const { container } = render(<Harness />);
+    expect(container.querySelector('[data-drop="1"]').hidden).toBe(false);
+    expect(container.querySelector('.content').dataset.clamped).toBeUndefined();
+    expect(container.querySelector('.reduced').hidden).toBe(true);
+  });
+
+  test('re-running is idempotent — drop state resets before measuring', () => {
+    const { container, rerender } = render(<Harness deps={[1]} />);
+    const dropped = container.querySelector('[data-drop="1"]');
+    dropped.hidden = true; // simulate a previous pass having sacrificed it
+    act(() => { rerender(<Harness deps={[2]} />); });
+    expect(dropped.hidden).toBe(false);
+  });
+
+  test('it removes its resize listener on unmount', () => {
+    const add = jest.spyOn(window, 'addEventListener');
+    const remove = jest.spyOn(window, 'removeEventListener');
+    const { unmount } = render(<Harness />);
+    const added = add.mock.calls.filter(([e]) => e === 'resize').length;
+    unmount();
+    const removed = remove.mock.calls.filter(([e]) => e === 'resize').length;
+    expect(removed).toBe(added);
+    add.mockRestore();
+    remove.mockRestore();
+  });
+
+  test('a null ref is survivable', () => {
+    function NullHarness() {
+      const ref = useRef(null);
+      useStageFit(ref, []);
+      return null;
+    }
+    expect(() => render(<NullHarness />)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd src && npx jest __tests__/stageShell.test.jsx
+```
+
+Expected: `Cannot find module '../hooks/useStageFit'`.
+
+- [ ] **Step 3: Write the hook**
+
+Create `src/src/hooks/useStageFit.js`. Port the measuring half from `docs/design/host-redesign/02-ask-call-and-answer.html` lines **803–1036**, replacing its `searchScale`, `sacrificeList` and `truncated` with the pure versions from `fitPolicy.js`, and its `window.__fit` + listener block with a React effect.
+
+The parts that must survive the port unchanged, because each is a fixed bug:
+
+```js
+/** Vertical only. This is the axis .content competes on, and adding width here
+ *  would import the same sub-pixel noise the truncation predicate had to be
+ *  rescued from. */
+function over(box) { return box.scrollHeight > box.clientHeight + 1; }
+
+/** Both axes, for chrome. The rail overflows sideways, and reusing the
+ *  vertical-only predicate for it meant the rail's own sacrifice loop could
+ *  never see the thing it existed to fix: measured at 1280 with a timer armed,
+ *  1298px of content in a 1280px bar, and not one group dropped. */
+function overAny(box) {
+  return box.scrollHeight > box.clientHeight + 1 || box.scrollWidth > box.clientWidth + 2;
+}
+```
+
+The orchestration, with the sacrifice loop now driven by `buildSacrificeList`:
+
+```js
+function fitContent(box) {
+  reset(box);
+  unwiden(box);
+  chooseLayout(box);
+  if (searchScale({ min: minFit(box), max: maxFit(box), isClean: () => clean(box), setScale: (v) => setFit(box, v) }) !== null) return;
+
+  const list = buildSacrificeList({
+    hasMeter: hasMeter(box), isSolo: isSolo(box), dropGroups: readDropGroups(box),
+  });
+  const lost = [];
+  for (let i = 0; i < list.length; i += 1) {
+    if (list[i].kind === 'meter') {
+      widen(box);
+    } else {
+      list[i].el.hidden = true;
+      if (list[i].note && lost.indexOf(list[i].note) === -1) lost.push(list[i].note);
+      announce(box, lost);
+    }
+    chooseLayout(box);
+    if (searchScale({ min: minFit(box), max: maxFit(box), isClean: () => clean(box), setScale: (v) => setFit(box, v) }) !== null) return;
+  }
+
+  // Terminal. Everything above failed, so abbreviate and say so. Reaching this
+  // point is a budget failure to fix, not a graceful landing.
+  box.dataset.clamped = 'on';
+  searchScale({ min: minFit(box), max: maxFit(box), isClean: () => !over(box), setScale: (v) => setFit(box, v) });
+}
+```
+
+`reset(box)` must clear `data-clamped`, the `--fit` inline property, the grid's `data-cols`, every `[data-drop]`'s `hidden`, and the `.reduced` note — **before** anything is measured. The hook is called on every render in practice, and a fitter that accumulates reductions instead of recomputing them converges on an empty screen.
+
+The effect:
+
+```js
+export default function useStageFit(stageRef, deps = []) {
+  useEffect(() => {
+    const root = stageRef.current;
+    if (!root) return undefined;
+
+    const run = () => {
+      root.querySelectorAll('.content').forEach(fitContent);
+      // Chrome boxes only sacrifice; their type is fixed by the profile and
+      // must not shrink with content.
+      root.querySelectorAll('.rail, .meter').forEach(fitChrome);
+    };
+
+    run();
+    // One more after paint: web fonts and images land after the first pass and
+    // change every measurement taken before them.
+    const raf = requestAnimationFrame(run);
+    window.addEventListener('resize', run);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', run);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd src && npx jest __tests__/stageShell.test.jsx
+```
+
+- [ ] **Step 5: Verify against the mockups, in a real browser**
+
+The Jest tests cannot see geometry. Before committing, confirm the ported fitter still behaves against the audited pages: serve `docs/design/host-redesign/` on any port, open `audit.html`, and run the suite.
+
+Expected: **168 checks, 0 failures**. If your port changed a mockup file to make this pass, you have changed the source of truth — revert it and fix the port instead.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/src/hooks/useStageFit.js src/src/__tests__/stageShell.test.jsx
+git commit -m "feat(stage): useStageFit — the measuring half of the fitter
+
+Forty lines of measure-and-apply around fitPolicy's decisions. It runs on
+mount, on resize, and whenever the question or answer list changes, and it
+resets rung and drop state before measuring because it is called on every
+render in practice — a fitter that accumulates reductions instead of
+recomputing them converges on an empty screen.
+
+over() stays vertical-only for content and both-axes for chrome. That is
+not a tidy-up: reusing the vertical predicate for the rail meant the
+rail's sacrifice loop could never see the overflow it existed to fix."
+```
+
+---
+
+### Task 4: The stage shell
+
+Five components carrying the three regions. They render the *existing* content — no new per-state design, which is plan 4.
+
+**Files:**
+- Create: `src/src/components/stage/Stage.jsx`, `Rail.jsx`, `PhaseBar.jsx`, `RoomMeter.jsx`, `Dock.jsx`
+- Test: `src/src/__tests__/stageShell.test.jsx` (append)
+
+**Interfaces:**
+- Consumes: `profileClass`, `loadProfile`, `saveProfile` from Task 1; `useStageFit` from Task 3; the existing `HostActionBar`.
+- Produces:
+  - `<Stage profile phase>{children}</Stage>` — applies the profile class to the document root and renders the four grid areas
+  - `<Rail title context join timer />`
+  - `<PhaseBar phase />`
+  - `<RoomMeter phase heading body />`
+  - `<Dock status hint onSetup>{primary}</Dock>`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/src/__tests__/stageShell.test.jsx`:
+
+```jsx
+import Stage from '../components/stage/Stage';
+import Rail from '../components/stage/Rail';
+import RoomMeter from '../components/stage/RoomMeter';
+
+describe('the stage grid', () => {
+  test('the profile class lands on the document root, not on a wrapper', () => {
+    // The ladders are declared on :root. A class on a div would leave every
+    // custom property substituting against :root's own values, which is
+    // precisely how the scalar approach rendered all four profiles identically.
+    render(<Stage profile="tv" phase="ASK"><div /></Stage>);
+    expect(document.documentElement.classList.contains('d-tv')).toBe(true);
+    expect(document.documentElement.classList.contains('d-room')).toBe(false);
+  });
+
+  test('changing profile replaces the class rather than adding one', () => {
+    const { rerender } = render(<Stage profile="tv" phase="ASK"><div /></Stage>);
+    rerender(<Stage profile="table" phase="ASK"><div /></Stage>);
+    expect(document.documentElement.className.match(/\bd-\w+/g)).toEqual(['d-table']);
+  });
+
+  test('all four grid areas are present in order', () => {
+    const { container } = render(<Stage profile="room" phase="ASK"><div /></Stage>);
+    const areas = Array.from(container.querySelectorAll('.stage > *'))
+      .map((el) => el.className.split(' ')[0]);
+    expect(areas).toEqual(['field', 'rail', 'bar', 'main', 'dock']);
+  });
+});
+
+describe('the rail', () => {
+  test('the title is a single text node, so its ellipsis can actually render', () => {
+    // text-overflow applies to a block container with inline content. On a flex
+    // box with span children it is inert, which is how the rail shipped
+    // clipping mid-glyph at -445px of slack.
+    const { container } = render(<Rail title="A very long event title" context={{}} join={{ code: '4821' }} />);
+    const title = container.querySelector('.rail-title');
+    expect(title.childNodes).toHaveLength(1);
+    expect(title.childNodes[0].nodeType).toBe(Node.TEXT_NODE);
+  });
+
+  test('the drop order sacrifices the title first and never the code', () => {
+    const { container } = render(<Rail title="T" context={{}} join={{ url: 'eng.seibtribe.us/play', code: '4821' }} />);
+    expect(container.querySelector('.rail-title').dataset.drop).toBe('1');
+    expect(container.querySelector('[data-join-word]').dataset.drop).toBe('2');
+    expect(container.querySelector('[data-join-url]').dataset.drop).toBe('3');
+    // The code is what people in the room need. It is not droppable at all.
+    expect(container.querySelector('code').dataset.drop).toBeUndefined();
+  });
+
+  test('the timer is absent unless armed', () => {
+    const { container, rerender } = render(<Rail title="T" context={{}} join={{ code: '1' }} />);
+    expect(container.querySelector('.rail-timer')).toBeNull();
+    rerender(<Rail title="T" context={{}} join={{ code: '1' }} timer="2:14" />);
+    expect(container.querySelector('.rail-timer')).not.toBeNull();
+  });
+});
+
+describe('the room meter', () => {
+  test('it states progress exactly once', () => {
+    // Six simultaneous statements of the same fact shipped once: the word
+    // ANSWERED, the numeral, a bar, a sentence, forty dots, and the dock.
+    // What survives is the labelled fraction. The bar and the dot matrix are
+    // deleted, and this is the test that keeps them deleted.
+    const { container } = render(<RoomMeter phase="ASK" heading="ANSWERED" body="31 / 40" />);
+    expect(container.querySelectorAll('.meter-bar')).toHaveLength(0);
+    expect(container.querySelectorAll('.meter-dot')).toHaveLength(0);
+    expect(container.textContent).toContain('31 / 40');
+  });
+
+  test('it never names anybody', () => {
+    // A count is a nudge; a list of names is an attendance record, and the room
+    // is the wrong audience for one. This binds Table too — Table is a stage.
+    const { container } = render(
+      <RoomMeter phase="ASK" heading="ANSWERED" body="31 / 40" players={[{ name: 'Dana' }, { name: 'Tomás' }]} />
+    );
+    expect(container.textContent).not.toMatch(/Dana|Tomás/);
+  });
+
+  test('it collapses where the spec says it collapses', () => {
+    const { container } = render(<RoomMeter phase="ENDED" heading="" body="" />);
+    expect(container.querySelector('.meter')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd src && npx jest __tests__/stageShell.test.jsx
+```
+
+- [ ] **Step 3: Write the components**
+
+Port from `docs/design/host-redesign/02-ask-call-and-answer.html`:
+
+| What | Lines |
+|---|---|
+| `.rail` and `.chip` | 149–196 |
+| `.rail-title` — the single-text-node rule and its `min-width:22ch` floor | 172–174 |
+| `.bar`, including the doubled striped `done` band | 198–206 |
+| `.main` and `.main.solo` | 207–218 |
+| `.content` / `.fitbox` | 219–243 |
+| `.dock` | 463 onward, to the end of that rule block |
+| stage markup | 766–790 |
+
+Two of those carry a correction each and must not be "tidied":
+
+- `.rail-title` has `min-width: 22ch`, not `min-width: 0`. With `0` the title shrank silently to a 14% stub — "Q3 Lead…", verbatim the string an evaluator complained about — while the rail never reported an overflow, so `fitChrome()` never fired and the drop ladder never ran. The floor is what makes the rail overflow, which is what triggers the sacrifice.
+- `.main` uses `grid-template-columns` with a `minmax(0,1fr)` content track. An `auto` track refuses to shrink below the min-content of its widest item, and one nowrap rail would otherwise push the whole stage past the viewport.
+
+**`.content` was partly written in Task 1** (the never-centre-a-clipping-box rule and the scaled tiers). Lines 219–243 overlap it. Merge rather than appending a second `.content` block — two rule sets for the same selector in one stylesheet is how the clamp ended up back in base CSS the first time. The Task 1 comments are the ones to keep; they say why.
+
+`Stage.jsx` applies the profile to `document.documentElement` in an effect and cleans up on unmount:
+
+```jsx
+useEffect(() => {
+  const root = document.documentElement;
+  const cls = profileClass(profile);
+  PROFILES.forEach((p) => root.classList.remove(`d-${p}`));
+  root.classList.add(cls);
+  return () => root.classList.remove(cls);
+}, [profile]);
+```
+
+`Dock.jsx` is a **grid row, not a fixed overlay**. This is a small change with a large consequence: `position: fixed` guarantees the control is *visible*, but a grid row guarantees it is *placed* — it cannot be covered by a rail, clipped by a `height: 100vh; overflow: hidden` ancestor (the exact bug documented at `styles.css:7190`), or reach a state where reserved padding fights the content. It reserves `--dock-h` per profile.
+
+`Dock.jsx` renders the existing `HostActionBar` for the primary action. **Do not reimplement its keyboard handling, its typing-target guard or its disabled-hint behaviour** — only its positioning CSS changes.
+
+The setup control is a minimum **48×48** target carrying the word `SETUP` beside the `⋯` glyph, at `--t-meta × 0.9` in `--muted`: a trackpad target from a foot away, an unreadable speck from the back row. It is not wired to anything in this plan — the Console is plan 3 — so it takes an `onSetup` prop and the caller passes a no-op for now.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd src && npx jest __tests__/stageShell.test.jsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/src/components/stage src/src/__tests__/stageShell.test.jsx
+git commit -m "feat(stage): the shell — rail, phase bar, main, dock
+
+The dock is a grid row, not a fixed overlay. position:fixed guarantees the
+control is visible; a grid row guarantees it is placed, so it cannot be
+covered by a rail or clipped by a height:100vh;overflow:hidden ancestor —
+which is the bug the big-screen CSS comment at styles.css:7190 documents.
+
+The rail title is a single text node because text-overflow is inert on a
+flex container with span children, which is how the rail shipped clipping
+mid-glyph with no ellipsis at all.
+
+The meter states progress once. The bar and the dot matrix are deleted:
+they were the second and third statements of a fact that needed one."
+```
+
+---
+
+### Task 5: `GameHostPage` adopts the shell
+
+The replacement, and the deletions. Both current layouts go at once — **do not add a third mode.**
+
+**Files:**
+- Modify: `src/src/GameHostPage.jsx`
+- Modify: `src/src/config/hostControls.js` — two additions
+- Test: `src/src/__tests__/stageShell.test.jsx` (append), `src/src/__tests__/hostControls.test.js` (append)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1, 3 and 4.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/src/__tests__/hostControls.test.js`:
+
+The real API is `hostControlsFor({ gameType, phase, … })` → `{ phase, primary, secondary, status }`. Note `hostControlsFor` opens with `const resolvedPhase = HOST_PHASES.includes(phase) ? phase : 'LOBBY'`, so **both new phases must be added to `HOST_PHASES` or they will silently resolve to `LOBBY`** — which is the same class of bug as `isWaitingState('ENDED')` returning `true`, and it would pass a careless test.
+
+```js
+import { HOST_PHASES, hostPhaseSequence, hostControlsFor } from '../config/hostControls';
+
+describe('the two additions the stage needs', () => {
+  // The trap first: an unknown phase resolves to LOBBY, so a new phase that is
+  // not in HOST_PHASES looks like it works and is actually rendering the lobby.
+  test('both new phases are recognised rather than falling back to LOBBY', () => {
+    expect(HOST_PHASES).toContain('FIELD_NOTES');
+    expect(HOST_PHASES).toContain('ENDED');
+    expect(hostControlsFor({ gameType: 'call-and-answer', phase: 'ENDED' }).phase).toBe('ENDED');
+    expect(hostControlsFor({ gameType: 'call-and-answer', phase: 'FIELD_NOTES' }).phase).toBe('FIELD_NOTES');
+  });
+
+  // RESULTS becomes two beats rather than one long screen.
+  test('RESULTS advances to the Field Notes beat before the next round', () => {
+    expect(hostControlsFor({ gameType: 'call-and-answer', phase: 'RESULTS' }).primary.id)
+      .toBe('field-notes');
+    expect(hostControlsFor({ gameType: 'call-and-answer', phase: 'FIELD_NOTES' }).primary.id)
+      .toBe('next');
+  });
+
+  // Today ENDED is a dead end: isWaitingState('ENDED') returns true, so a
+  // finished session renders the lobby.
+  test('ENDED offers a way forward', () => {
+    expect(hostControlsFor({ gameType: 'call-and-answer', phase: 'ENDED' }).primary)
+      .toEqual(expect.objectContaining({ id: 'report', label: 'Open Session Report' }));
+  });
+
+  // The existing invariant, restated because these additions are exactly the
+  // kind of change that breaks it.
+  test('every (type × phase) pair still yields exactly one primary', () => {
+    for (const type of ['call-and-answer', 'trivia', 'poll', 'wavelength', 'survey']) {
+      for (const phase of hostPhaseSequence(type).concat(['FIELD_NOTES', 'ENDED'])) {
+        const controls = hostControlsFor({ gameType: type, phase });
+        expect(controls.primary).toBeTruthy();
+        expect(controls.primary.id).toBeTruthy();
+      }
+    }
+  });
+
+  // ASK is the one phase with a secondary. Adding phases must not grow that.
+  test('the new phases add no secondary action', () => {
+    expect(hostControlsFor({ gameType: 'call-and-answer', phase: 'FIELD_NOTES' }).secondary).toBeNull();
+    expect(hostControlsFor({ gameType: 'call-and-answer', phase: 'ENDED' }).secondary).toBeNull();
+  });
+});
+```
+
+Append to `src/src/__tests__/stageShell.test.jsx`:
+
+```jsx
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * The deletions, asserted against the source.
+ *
+ * These are not style preferences — each is a named defect in the spec, and
+ * each is the kind of thing that survives a refactor by being left "just in
+ * case". Reading the file is crude, and it is also the only way to prove a
+ * line is gone without rendering a 5,000-line component that currently cannot
+ * mount in jsdom at all (see the five stale suites in the baseline).
+ */
+describe('what must be deleted, not adapted', () => {
+  const source = readFileSync(join(__dirname, '..', 'GameHostPage.jsx'), 'utf8');
+
+  test('the bigScreenMode reset effect is gone', () => {
+    // A projector browser that reloads must come back exactly as it was.
+    expect(source).not.toMatch(/setBigScreenMode\(false\)/);
+  });
+
+  test('ENDED is no longer treated as a waiting state', () => {
+    // isWaitingState('ENDED') returning true is why a finished session renders
+    // the lobby — "Waiting for players to join…" after everyone has left.
+    expect(source).not.toMatch(/isWaitingState[\s\S]{0,400}['"]ENDED['"]/);
+  });
+
+  test('the answer-navigator is gone', () => {
+    expect(source).not.toMatch(/answer-navigator/);
+  });
+
+  test('the parallax block is gone', () => {
+    expect(source).not.toMatch(/className=["'][^"']*\bparallax\b/);
+  });
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cd src && npx jest __tests__/hostControls.test.js __tests__/stageShell.test.jsx
+```
+
+- [ ] **Step 3: Add the two `hostControls` entries**
+
+In `src/src/config/hostControls.js`:
+
+1. Extend `HOST_PHASES` to `['LOBBY', 'ASK', 'VOTE', 'RESULTS', 'FIELD_NOTES', 'ENDED']`. Without this, `hostControlsFor`'s `resolvedPhase` guard silently rewrites both new phases to `LOBBY`.
+2. Add the `RESULTS` → `FIELD_NOTES` → `NEXT` sub-sequence in `primaryFor`, so RESULTS has two beats rather than one long screen.
+3. Add the `ENDED` case returning `{ id: 'report', label: 'Open Session Report' }`.
+4. Extend `statusTextFor` to cover both new phases — it is keyed on phase and will otherwise fall through to the lobby's copy.
+
+**Change nothing else in this file.** The spec names its decision logic as needing no change beyond these, and the existing invariant test is what keeps the dock honest.
+
+Leave `hostPhaseSequence` returning the round's phases only. It describes the phases a *round* passes through; `FIELD_NOTES` is a beat inside RESULTS and `ENDED` is a session state, and folding either into the round sequence would make the phase bar draw a fifth segment per round.
+
+- [ ] **Step 4: Render the shell**
+
+In `src/src/GameHostPage.jsx`, replace both current layouts with the shell. Hold the profile in state, initialised from `loadProfile(window.localStorage, window.innerWidth)`, and call `saveProfile` whenever it changes. Call `useStageFit(stageRef, [question, answers, phase, profile])`.
+
+- [ ] **Step 5: Delete, do not adapt**
+
+Each of these is a named defect. Remove them outright:
+
+- the `bigScreenMode` reset effect (`:189–192`)
+- the `isWaitingState` treatment of `ENDED` (`:59–67`)
+- the `showConfirmation` end-of-game flow (`:961–975`) — a dialog box is not how a session ends
+- the `answer-navigator` (`:3946–3975`)
+- the three non-loading flash alerts (`:4401–4432`)
+- the `.parallax` block in the host container (`:3671–3686`)
+
+Line numbers are from the spec and will have drifted; find them by name.
+
+- [ ] **Step 6: Verify the full baseline**
+
+```bash
+cd src && npx jest __tests__/ && npm run build
+```
+
+Expected: **5** failed suites (the stale ones, unchanged) and no new failures; build compiles with the 2 pre-existing size warnings.
+
+Then confirm the real thing in a browser — the Jest suite cannot see geometry, and this is the task where geometry starts mattering:
+
+```bash
+cd src && npm start
+```
+
+Walk one call-and-answer round at 1920×1080 and at 1280×720, in Room and in Table. Confirm: the page does not scroll, the primary action is on screen at both sizes, the question is not decapitated, and reloading mid-session comes back on the same profile.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/src/GameHostPage.jsx src/src/config/hostControls.js src/src/__tests__/stageShell.test.jsx src/src/__tests__/hostControls.test.js
+git commit -m "feat(stage): GameHostPage renders the stage shell
+
+Both layouts are replaced at once rather than adding a third mode. Two
+modes is what produced two ASK headers and two QR blocks, and the mode did
+not survive a reload, so it failed silently in front of a room.
+
+Six deletions land with it, each a named defect: the bigScreenMode reset,
+ENDED treated as a waiting state (which is why a finished session renders
+the lobby), the end-of-game dialog, the answer-navigator, three flash
+alerts and the parallax block."
+```
+
+---
+
+## Manual verification before handing back
+
+The Jest suites cover the policy and the lifecycle. These cannot be asserted in jsdom and must be walked through:
+
+1. **`audit.html` against the mockups still reports 168 checks / 0 failures** after the fitter port. If it does not, the port changed behaviour.
+2. **The four profiles measurably differ in the running app.** Switch between them and confirm the rail chip and dock button change size — those read the profile tokens directly and are never re-scaled, so they are the honest answer to "did the profile change anything". Four profiles that render identically is the exact failure the scalar approach shipped.
+3. **A reload mid-session returns on the same profile.** This is the requirement the deleted reset effect was violating.
+4. **A long question at 1280×720 in TV.** TV's ladder cannot be honoured below ~820px of viewport height on dense states even after every reduction; confirm it drops something rather than clipping.
+
+## Out of scope, recorded
+
+- **Running `audit.js` against the React app in a real browser.** The checks are pure functions over a rendered document and a viewport, so they port unchanged — but they need a headless-browser harness this repo does not have, and jsdom cannot substitute. Worth its own plan; until it exists the geometric guarantee is held by the mockups, not by the app.
+- **The Console** (§5.4), including the Display section that selects TV and Call. Until it ships, those two profiles are reachable only by setting `localStorage` by hand. Plan 3.
+- **Per-state content and the deletions in §6.** Plan 4.
+- **ENDED and the Field Notes beat as surfaces.** This plan adds their `hostControls` entries so the dock has somewhere to point; the screens themselves are plan 5.
+- **`POST /games/{id}/reopen-round`** (spec R2). A host who advances early cannot recover, and the shipped mitigation is the arm-then-fire confirmation, not an undo.

--- a/lambda-functions/game/anonymity.js
+++ b/lambda-functions/game/anonymity.js
@@ -25,11 +25,38 @@
 const ANON_FIELDS = ['playerId', 'playerName', 'name'];
 
 /**
+ * Formats whose round never opens a vote.
+ *
+ * INLINED ON PURPOSE. The canonical vocabulary lives in game-types.js, and the
+ * host's runtime answer lives in src/src/config/hostControls.js
+ * (`hostRunsVotePhase`) — but this file must stay byte-identical across
+ * lambda-functions/game/ and lambda-functions/websocket/, and game-types.js
+ * exists only in the former. A require() that resolves in one bundle and not
+ * the other is worse than a duplicated four-element set.
+ * tests/anonymity-contract.js asserts this set still agrees with game-types.js
+ * for every spelling the table can hold, aliases included.
+ */
+const TYPES_THAT_SKIP_VOTE = new Set(['trivia', 'wavelength', 'quiz']);
+
+function skipsVote(gameType) {
+  return TYPES_THAT_SKIP_VOTE.has(String(gameType || '').trim().toLowerCase());
+}
+
+/**
  * @param {object} metadata the GAME#id / METADATA item
  * @param {object} round    the round record carrying AuthorsRevealed
  * @returns {boolean} true when attribution must be withheld
  */
 function isHidden(metadata, round) {
+  // Anonymity binds only the formats that hold a vote. Trivia's response is a
+  // letter, so there is nothing authored to attribute — and redacting it breaks
+  // the host's view of who answered what. Wavelength never attributes on stage.
+  //
+  // This check is not cosmetic. The flag defaults ON, and every game created
+  // before this feature has no HostPreferences at all, so without it every
+  // legacy trivia and wavelength game is silently redacted.
+  if (skipsVote(metadata && metadata.GameType)) return false;
+
   const prefs = (metadata && metadata.HostPreferences) || {};
   const anonymous = prefs.anonymousUntilReveal !== false; // default ON
   const revealed = !!(round && round.AuthorsRevealed);

--- a/lambda-functions/game/get-ai-summary.js
+++ b/lambda-functions/game/get-ai-summary.js
@@ -470,6 +470,47 @@ exports.resolvePromptTemplate = resolvePromptTemplate;
 exports.isUsableSummaryPrompt = isUsableSummaryPrompt;
 exports.summaryPromptDefect = summaryPromptDefect;
 
+/**
+ * The words two or more participants submitted in a wavelength round, most
+ * frequent first, as `[{ word, count }]`.
+ *
+ * A wavelength round is scored as a team: the score everyone shares is simply
+ * how many words the room landed on together. That count is needed in two
+ * places that do not share a scope — exports.handler's vote-tally pass (which
+ * scores the players) and generateAISummary's word analysis (which briefs the
+ * model) — and the two must not disagree, or the room is shown one number
+ * while the model is told another. Hence one derivation, here.
+ *
+ * `storedResults` is the QUESTION#nnn#RESULTS record get-results.js writes; it
+ * already holds the analysis, so prefer it. It is absent for rounds whose
+ * results call never completed, so fall back to counting the answers with the
+ * same rule get-results.js used (a word shared by 2+ participants).
+ *
+ * Returns counts only — never author names — so it is safe to call while a
+ * round is still anonymous.
+ */
+function deriveWavelengthCommonWords(storedResults, answers) {
+  const stored = storedResults && storedResults.wordAnalysis && storedResults.wordAnalysis.commonWords;
+  if (Array.isArray(stored)) return stored;
+
+  const wordCounts = {};
+  (answers || []).forEach(answer => {
+    const answerText = answer.Answer || answer.answer || '';
+    answerText.split(',')
+      .map(w => w.trim().toLowerCase())
+      .filter(w => w.length > 0)
+      .forEach(word => { wordCounts[word] = (wordCounts[word] || 0) + 1; });
+  });
+
+  return Object.entries(wordCounts)
+    .filter(([, count]) => count > 1)
+    .sort((a, b) => b[1] - a[1])
+    .map(([word, count]) => ({ word, count }));
+}
+
+// Exported for tests/wavelength-ai-summary.js
+exports.deriveWavelengthCommonWords = deriveWavelengthCommonWords;
+
 exports.handler = async (event) => {
   // Async worker mode: the HTTP path fires an InvocationType:'Event' self-invoke
   // with __workerMode set, so the full generation runs off the API Gateway 30s
@@ -862,8 +903,15 @@ exports.handler = async (event) => {
         console.log(`🔍 AI TRIVIA DEBUG - Player ${voteTallies[index].playerName}: points=${pointsEarned}, correct=${isCorrect}, base=${voteTallies[index].basePoints}, bonus=${voteTallies[index].speedBonus}`);
       });
     } else if (gameType === 'wavelength') {
-      // For wavelength games, everyone gets the same team score (number of common words found)
-      const teamScore = (commonWords && Array.isArray(commonWords)) ? commonWords.length : 0;
+      // For wavelength games, everyone gets the same team score (number of
+      // common words found). This used to read a bare `commonWords`, which is
+      // declared only inside generateAISummary — a different function with no
+      // closure over this scope — so it was an undeclared-variable reference
+      // that threw ReferenceError on every wavelength round, killing Field
+      // Notes for this game type entirely. Derive it here instead, from the
+      // stored results this handler already fetched above.
+      const commonWords = deriveWavelengthCommonWords(storedResults, answers);
+      const teamScore = commonWords.length;
       
       answers.forEach((answer, index) => {
         voteTallies[index].totalScore = teamScore;
@@ -1201,13 +1249,16 @@ exports.buildFallbackSummary = buildFallbackSummary;
 
 // Exported for the same reason as buildFallbackSummary: it lets the anonymity
 // redaction inside this function (below) be exercised directly, without a full
-// exports.handler round trip. That matters specifically for the wavelength
-// branch — reaching it via exports.handler currently throws on an unrelated,
-// pre-existing bug (the outer handler's own vote-tally pass for wavelength
-// games references `commonWords`, which is never declared in that scope; see
-// the fix report for task 7). That bug is out of scope here and left alone,
-// but it means the wavelength redaction fixed in this task could only be
-// given real test coverage by calling this function directly.
+// exports.handler round trip.
+//
+// The wavelength branch used to be unreachable that way at all: the outer
+// handler's own vote-tally pass referenced a `commonWords` that was never
+// declared in its scope, so every wavelength round threw ReferenceError before
+// this function was called. That is fixed (see deriveWavelengthCommonWords
+// above, and tests/wavelength-ai-summary.js, which drives the handler), so the
+// direct-call coverage in tests/anonymous-round-flow.js is no longer the only
+// way in — it is kept because unit-testing the redaction here is still the
+// clearer test.
 exports.generateAISummary = generateAISummary;
 
 async function generateAISummary({ eventTitle, gameType, gameAiContext, questionSetAiContext, customInstruction, promptId, promptProvenance, debugMode, questionId, question, answers, results, votes, gameId, questionSetId, paddedQuestionNumber, scoringConfig, hostPersonaId, setPersonaId, hidden, storedResults }) {

--- a/lambda-functions/game/get-ai-summary.js
+++ b/lambda-functions/game/get-ai-summary.js
@@ -8,6 +8,7 @@ const { resolvePersona, buildOutputContract, hasCustomOutputShape, describeOutpu
 const { normalizeGameType } = require('./game-types');
 const { isUsableSummaryPrompt, summaryPromptDefect } = require('./prompt-shape');
 const { resolveSetPartition } = require('./set-version');
+const { isHidden } = require('./anonymity');
 
 /**
  * Voice attribution carried out of generateAISummary() and onto the stored
@@ -897,6 +898,18 @@ exports.handler = async (event) => {
 
     const metadata = gameMetadata.Item;
 
+    // Whether this round's answers may be attributed. Loaded once, here,
+    // and threaded through to generateAISummary — both the deterministic
+    // fallback template AND the model prompt itself must not name an
+    // unrevealed author, and the round record is what settles that (per
+    // round, not per game — a host may reveal round 1 and still be mid-round
+    // on round 2).
+    const roundRecord = await db.send(new GetCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: { PK: `GAME#${gameId}`, SK: `ROUND#${paddedQuestionNumber}` }
+    }));
+    const hidden = isHidden(metadata, roundRecord.Item);
+
     // Fetch question set details for AI context and custom instructions
     let customInstruction = null;
     let questionSetAiContext = null;
@@ -1022,7 +1035,8 @@ exports.handler = async (event) => {
       gameId: gameId,
       questionSetId: questionSetId,
       paddedQuestionNumber: paddedQuestionNumber,
-      scoringConfig: scoringConfig
+      scoringConfig: scoringConfig,
+      hidden: hidden
     };
 
     // Generate AI summary
@@ -1141,17 +1155,87 @@ exports.handler = async (event) => {
   }
 };
 
-async function generateAISummary({ eventTitle, gameType, gameAiContext, questionSetAiContext, customInstruction, promptId, promptProvenance, debugMode, questionId, question, answers, results, votes, gameId, questionSetId, paddedQuestionNumber, scoringConfig, hostPersonaId, setPersonaId }) {
+/**
+ * The deterministic fallback summary.
+ *
+ * Exported so the anonymity branch can be tested without invoking Bedrock. This
+ * template — not the model — is what named and quoted the top contributor on
+ * every single round before anonymity existed.
+ *
+ * `hidden` must fall back to an unattributed form. The Field Notes beat is
+ * ordered after the reveal, so in the normal flow attribution is already
+ * public by the time this renders — but a host may press Next Round without
+ * ever revealing, and the promise made to the room has to survive that.
+ */
+function buildFallbackSummary({ totalParticipants, votesCast, top, gameType, question, hidden }) {
+  const isTrivia = gameType === 'trivia';
+  const qText = typeof question === 'string' ? question
+    : (question && (question.title || question.Title || question.questionDetail || question.Detail)) || '';
+  const parts = [`${totalParticipants} ${totalParticipants === 1 ? 'response was' : 'responses were'} submitted${qText ? ` on "${qText}"` : ''}.`];
+  if (votesCast > 0) parts.push(`${votesCast} vote${votesCast === 1 ? '' : 's'} cast.`);
+
+  if (top && top.answer) {
+    const support = `earned the most support (${top.score} point${top.score === 1 ? '' : 's'}${top.votes ? `: ${top.votes}` : ''})`;
+    if (hidden) {
+      // No name, and no verbatim quote either — on a small round a distinctive
+      // phrase identifies its author as surely as the name would.
+      parts.push(`The most-supported response ${support}.`);
+    } else if (top.playerName) {
+      parts.push(`${top.playerName}'s answer${isTrivia ? '' : `, "${top.answer}",`} ${support}.`);
+    }
+  } else if (totalParticipants > 0) {
+    parts.push('The group shared a range of perspectives.');
+  }
+  return parts.join(' ');
+}
+
+exports.buildFallbackSummary = buildFallbackSummary;
+
+async function generateAISummary({ eventTitle, gameType, gameAiContext, questionSetAiContext, customInstruction, promptId, promptProvenance, debugMode, questionId, question, answers, results, votes, gameId, questionSetId, paddedQuestionNumber, scoringConfig, hostPersonaId, setPersonaId, hidden }) {
+  // ANONYMITY: while hidden, nothing that ties this round's answer to its
+  // author may reach the model — not just the deterministic fallback below.
+  // The model's OWN generated summary is built from the template variables
+  // this function assembles, so leaving real names in `answers` or
+  // `results` would just let the LLM write "Ada's answer..." straight back
+  // into the Field Notes panel.
+  //
+  // `answers` and `results.voteTallies`/`results.winners` are the two places
+  // this round's authorship enters this function (both ultimately sourced
+  // from the same ANSWER# records get-answers.js and start-vote.js already
+  // redact for their own payloads). Swap the name for a placeholder in both,
+  // once, here — the dozen prompt-section builders below then keep working
+  // unmodified instead of each having to special-case anonymity.
+  //
+  // A flat, repeated placeholder (not a numbered "Participant 1",
+  // "Participant 2", ...) is deliberate: a stable per-participant anonymous
+  // identity is the stable-answerId feature, out of scope for this task —
+  // this only has to stop the model being TOLD who wrote what. Substituting
+  // rather than deleting the field also matters here, unlike the "omit, not
+  // null" contract in anonymity.js's own redactAnswer(): these values feed
+  // English prose (`"${a.playerName}'s answer..."`), where an omitted field
+  // renders as the literal string "undefined", not a safely absent key.
+  const AUTHOR_PLACEHOLDER = 'a participant';
+  if (hidden) {
+    answers = answers.map((a) => ({ ...a, playerName: AUTHOR_PLACEHOLDER, PlayerName: AUTHOR_PLACEHOLDER }));
+    results = {
+      ...results,
+      voteTallies: Object.fromEntries(
+        Object.entries(results.voteTallies || {}).map(([idx, data]) => [idx, { ...data, playerName: AUTHOR_PLACEHOLDER }])
+      ),
+      winners: (results.winners || []).map((w) => ({ ...w, playerName: AUTHOR_PLACEHOLDER })),
+    };
+  }
+
   // Prepare the context for AI
   const totalParticipants = answers.length;
   const winners = results.winners || [];
   const voteTallies = results.voteTallies || {};
-  
+
   // Get top 3 answers based on vote tallies (by index like get-results.js)
   const sortedAnswers = Object.entries(voteTallies)
     .sort(([,a], [,b]) => b.totalScore - a.totalScore)
     .slice(0, 3);
-  
+
   const topAnswers = sortedAnswers.map(([index, voteData]) => {
     return {
       playerName: voteData.playerName,
@@ -1167,17 +1251,7 @@ async function generateAISummary({ eventTitle, gameType, gameAiContext, question
   const buildFallback = () => {
     const votesCast = (results && results.totalVotes) || 0;
     const top = topAnswers[0];
-    const isTrivia = gameType === 'trivia';
-    const qText = typeof question === 'string' ? question
-      : (question && (question.title || question.Title || question.questionDetail || question.Detail)) || '';
-    const parts = [`${totalParticipants} ${totalParticipants === 1 ? 'response was' : 'responses were'} submitted${qText ? ` on "${qText}"` : ''}.`];
-    if (votesCast > 0) parts.push(`${votesCast} vote${votesCast === 1 ? '' : 's'} cast.`);
-    if (top && top.playerName && top.answer) {
-      parts.push(`${top.playerName}'s answer${isTrivia ? '' : `, "${top.answer}",`} earned the most support (${top.score} point${top.score === 1 ? '' : 's'}${top.votes ? `: ${top.votes}` : ''}).`);
-    } else if (totalParticipants > 0) {
-      parts.push('The group shared a range of perspectives.');
-    }
-    const summaryText = parts.join(' ');
+    const summaryText = buildFallbackSummary({ totalParticipants, votesCast, top, gameType, question, hidden });
     const discussionQuestions = [
       'What stood out to you in the responses?',
       top && top.answer ? `What made "${top.answer}" resonate with the group?` : 'Where did the group agree or differ most?'

--- a/lambda-functions/game/get-ai-summary.js
+++ b/lambda-functions/game/get-ai-summary.js
@@ -1036,7 +1036,15 @@ exports.handler = async (event) => {
       questionSetId: questionSetId,
       paddedQuestionNumber: paddedQuestionNumber,
       scoringConfig: scoringConfig,
-      hidden: hidden
+      hidden: hidden,
+      // Fixes a latent bug found while covering this task's wavelength fix:
+      // generateAISummary's wavelength branch already read `storedResults`
+      // (line ~1830 below) without it ever being passed in — a plain
+      // ReferenceError on every wavelength game that reaches that branch,
+      // unrelated to anonymity. Wiring it through is the minimum needed to
+      // make that branch (and this task's redaction inside it) reachable at
+      // all, let alone testable.
+      storedResults: storedResults
     };
 
     // Generate AI summary
@@ -1191,7 +1199,18 @@ function buildFallbackSummary({ totalParticipants, votesCast, top, gameType, que
 
 exports.buildFallbackSummary = buildFallbackSummary;
 
-async function generateAISummary({ eventTitle, gameType, gameAiContext, questionSetAiContext, customInstruction, promptId, promptProvenance, debugMode, questionId, question, answers, results, votes, gameId, questionSetId, paddedQuestionNumber, scoringConfig, hostPersonaId, setPersonaId, hidden }) {
+// Exported for the same reason as buildFallbackSummary: it lets the anonymity
+// redaction inside this function (below) be exercised directly, without a full
+// exports.handler round trip. That matters specifically for the wavelength
+// branch — reaching it via exports.handler currently throws on an unrelated,
+// pre-existing bug (the outer handler's own vote-tally pass for wavelength
+// games references `commonWords`, which is never declared in that scope; see
+// the fix report for task 7). That bug is out of scope here and left alone,
+// but it means the wavelength redaction fixed in this task could only be
+// given real test coverage by calling this function directly.
+exports.generateAISummary = generateAISummary;
+
+async function generateAISummary({ eventTitle, gameType, gameAiContext, questionSetAiContext, customInstruction, promptId, promptProvenance, debugMode, questionId, question, answers, results, votes, gameId, questionSetId, paddedQuestionNumber, scoringConfig, hostPersonaId, setPersonaId, hidden, storedResults }) {
   // ANONYMITY: while hidden, nothing that ties this round's answer to its
   // author may reach the model — not just the deterministic fallback below.
   // The model's OWN generated summary is built from the template variables
@@ -1252,9 +1271,17 @@ async function generateAISummary({ eventTitle, gameType, gameAiContext, question
     const votesCast = (results && results.totalVotes) || 0;
     const top = topAnswers[0];
     const summaryText = buildFallbackSummary({ totalParticipants, votesCast, top, gameType, question, hidden });
+    // Same standard as buildFallbackSummary above: while hidden, no verbatim
+    // quote either — a distinctive phrase can out an author on a small round
+    // just as surely as a name would, and this renders into the same
+    // markdownResponse under "### Discussion topics".
     const discussionQuestions = [
       'What stood out to you in the responses?',
-      top && top.answer ? `What made "${top.answer}" resonate with the group?` : 'Where did the group agree or differ most?'
+      top && top.answer
+        ? (hidden
+            ? 'What made the most-supported response resonate with the group?'
+            : `What made "${top.answer}" resonate with the group?`)
+        : 'Where did the group agree or differ most?'
     ];
     const nextSteps = ['Pick one takeaway from this question to apply to your own work this week.'];
     const markdownResponse =
@@ -1814,22 +1841,35 @@ async function generateAISummary({ eventTitle, gameType, gameAiContext, question
       totalUniqueWords = storedResults.wordAnalysis.totalUniqueWords || 0;
       connectionScore = storedResults.wordAnalysis.connectionScore || 0;
       
-      // Extract player word lists from stored data
-      const playerWordLists = {};
+      // Extract player word lists from stored data. This reads a separately
+      // persisted QUESTION#...#RESULTS record — it is NOT part of the
+      // `answers`/`results` parameters redacted at the top of this function,
+      // so real names here must be scrubbed again, on their own, or they
+      // reach the model (and, via debug=true, any caller) untouched.
+      //
+      // An array of entries, not an object keyed by player name: keying by
+      // name means every redacted row collides on the same placeholder key
+      // and silently overwrites the one before it, so only the last
+      // participant's words would survive into wavelengthWords below. An
+      // array keeps every participant's words without needing a stable
+      // per-participant identity (that would be the stable-answerId feature,
+      // out of scope here) — the placeholder can simply repeat.
+      const playerWordEntries = [];
       if (storedResults.playerAnswers) {
         storedResults.playerAnswers.forEach(playerAnswer => {
-          const playerName = playerAnswer.playerName || playerAnswer.PlayerName;
+          const rawName = playerAnswer.playerName || playerAnswer.PlayerName;
+          const playerName = hidden ? AUTHOR_PLACEHOLDER : rawName;
           const answerText = playerAnswer.answer || playerAnswer.Answer || '';
           const words = answerText.split(',')
             .map(w => w.trim().toLowerCase())
             .filter(w => w.length > 0);
-          playerWordLists[playerName] = words;
+          playerWordEntries.push({ playerName, words });
         });
       }
-      
+
       // Format wavelength data for AI
-      wavelengthWords = Object.entries(playerWordLists)
-        .map(([player, words]) => `${player}: [${words.join(', ')}]`)
+      wavelengthWords = playerWordEntries
+        .map(({ playerName, words }) => `${playerName}: [${words.join(', ')}]`)
         .join('; ');
       
       wordAnalysis = `${commonWords.length} common words found out of ${totalUniqueWords} unique words (${connectionScore}% connection rate). ` +
@@ -1844,41 +1884,47 @@ async function generateAISummary({ eventTitle, gameType, gameAiContext, question
     } else {
       console.log('⚠️ No stored results found, calculating wavelength data from scratch');
       
-      // Fallback: Process all player words to find common ones
+      // Fallback: Process all player words to find common ones. `answers` was
+      // already redacted to the shared placeholder at the top of this
+      // function when hidden, so `playerName` below is safe as-is — but an
+      // array of entries, not an object keyed by player name, same reason as
+      // the stored-results branch above: keying by name collapses every
+      // redacted row onto the same placeholder key and drops every
+      // participant but the last from wavelengthWords.
       const wordCounts = {};
-      const playerWordLists = {};
+      const playerWordEntries = [];
       let totalWordsSubmitted = 0;
-      
+
       answers.forEach(answer => {
         const playerName = answer.PlayerName || answer.playerName;
         const answerText = answer.Answer || answer.answer || '';
-        
+
         // Parse words (should already be normalized from message.js processing)
         const words = answerText.split(',')
           .map(w => w.trim().toLowerCase())
           .filter(w => w.length > 0);
-        
-        playerWordLists[playerName] = words;
+
+        playerWordEntries.push({ playerName, words });
         totalWordsSubmitted += words.length;
-        
+
         // Count word frequencies
         words.forEach(word => {
           wordCounts[word] = (wordCounts[word] || 0) + 1;
         });
       });
-      
+
       // Find common words (mentioned by 2+ players)
       commonWords = Object.entries(wordCounts)
         .filter(([word, count]) => count > 1)
         .sort((a, b) => b[1] - a[1]) // Sort by frequency
         .map(([word, count]) => ({ word, count }));
-      
+
       totalUniqueWords = Object.keys(wordCounts).length;
       connectionScore = Math.round((commonWords.length / totalUniqueWords) * 100) || 0;
-      
+
       // Format wavelength data for AI
-      wavelengthWords = Object.entries(playerWordLists)
-        .map(([player, words]) => `${player}: [${words.join(', ')}]`)
+      wavelengthWords = playerWordEntries
+        .map(({ playerName, words }) => `${playerName}: [${words.join(', ')}]`)
         .join('; ');
       
       wordAnalysis = `${commonWords.length} common words found out of ${totalUniqueWords} unique words (${connectionScore}% connection rate). ` +

--- a/lambda-functions/game/get-answers.js
+++ b/lambda-functions/game/get-answers.js
@@ -1,5 +1,6 @@
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient, GetCommand, QueryCommand } = require('@aws-sdk/lib-dynamodb');
+const { isHidden, redactAnswers } = require('./anonymity');
 
 const client = new DynamoDBClient({});
 const db = DynamoDBDocumentClient.from(client);
@@ -73,13 +74,35 @@ exports.handler = async (event) => {
     console.log(`📊 Found ${answers.length} answers for question ${targetQuestionId}`);
 
     // Base answer information
-    const baseAnswers = answers.map(answer => ({
+    const fullAnswers = answers.map(answer => ({
       playerName: answer.PlayerName,
       name: answer.PlayerName, // Add name field for frontend compatibility
       answer: answer.Answer,
       answerType: answer.AnswerType || 'text',
       submittedAt: answer.SubmittedAt
     }));
+
+    // Anonymity is decided here, once, for both role branches below.
+    //
+    // There is deliberately no host exemption: `role` arrives as a query
+    // parameter (see :11), so a payload we would emit to role=host we would
+    // emit to anybody who typed it. The only implementable guarantee is that
+    // the names are not in the response at all.
+    const [metaRes, roundRes] = await Promise.all([
+      db.send(new GetCommand({
+        TableName: process.env.TABLE_NAME,
+        Key: { PK: `GAME#${gameId}`, SK: 'METADATA' }
+      })),
+      db.send(new GetCommand({
+        TableName: process.env.TABLE_NAME,
+        Key: { PK: `GAME#${gameId}`, SK: `ROUND#${targetQuestionId}` }
+      }))
+    ]);
+
+    const hidden = isHidden(metaRes.Item, roundRes.Item);
+    // Order is preserved by redactAnswers and must stay that way: the ballot is
+    // positional and get-results tallies vote index against answers[index].
+    const baseAnswers = hidden ? redactAnswers(fullAnswers) : fullAnswers;
 
     // Role-specific information
     if (role === 'host') {

--- a/lambda-functions/game/get-results.js
+++ b/lambda-functions/game/get-results.js
@@ -139,6 +139,30 @@ const enterResultsState = async (gameId, paddedQuestionId) => {
     }
   }));
 
+  // VOTING HAS CLOSED, SO THE PROMISE IS DISCHARGED. The room was told "nobody
+  // sees who wrote what — the host included — until voting closes", and this is
+  // that moment. Attribution returns everywhere from here: results, Field Notes,
+  // standings, the report and the archive export.
+  //
+  // It lives in this function rather than at the call sites for the reason the
+  // comment above records — the state write used to be pasted into two branches
+  // and missing from the wavelength and zero-vote exits, so a round could close
+  // without it. The reveal must not inherit that hole.
+  //
+  // Unconditional SET, so it is idempotent: a host who resolves the same round
+  // twice does not error, and POST /reveal-authors having run first is a no-op.
+  await db.send(new UpdateCommand({
+    TableName: process.env.TABLE_NAME,
+    Key: { PK: `GAME#${gameId}`, SK: `ROUND#${paddedQuestionId}` },
+    UpdateExpression: 'SET #revealed = :true, #qn = :qn, #updatedAt = :updatedAt',
+    ExpressionAttributeNames: {
+      '#revealed': 'AuthorsRevealed', '#qn': 'QuestionNumber', '#updatedAt': 'UpdatedAt'
+    },
+    ExpressionAttributeValues: {
+      ':true': true, ':qn': paddedQuestionId, ':updatedAt': new Date().toISOString()
+    }
+  }));
+
   await broadcastResultsReady(gameId, paddedQuestionId);
 };
 

--- a/lambda-functions/game/reveal-authors.js
+++ b/lambda-functions/game/reveal-authors.js
@@ -1,0 +1,117 @@
+/**
+ * End the anonymity of one round.
+ *
+ * The reveal is the primary action of RESULTS, not an automatic consequence of
+ * arriving there (§5.6.4) — so this is an endpoint the host calls, and the beat
+ * order is RESULTS (anonymous) -> RESULTS (revealed) -> What we heard -> Next.
+ * A host cannot forget to reveal, because revealing is the only way forward.
+ *
+ * PER ROUND, NOT PER GAME. A host may reveal round 3 and end the session before
+ * round 4, and round 4 must stay anonymous forever in the report.
+ *
+ * IDEMPOTENT. The host is standing in front of a room; a double-tap must not
+ * produce an error, and revealing something already revealed is a no-op that
+ * still returns the rows.
+ *
+ * This does not un-send anything. `‹ Hide again` on the stage is display-only —
+ * the payload has already been delivered. Do not describe it as a security
+ * control.
+ */
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, QueryCommand, UpdateCommand } = require('@aws-sdk/lib-dynamodb');
+const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require('@aws-sdk/client-apigatewaymanagementapi');
+
+const client = new DynamoDBClient({});
+const db = DynamoDBDocumentClient.from(client);
+
+const broadcastToGame = async (gameId, message) => {
+  try {
+    const apigateway = new ApiGatewayManagementApiClient({
+      endpoint: process.env.WEBSOCKET_API_ENDPOINT
+    });
+    const res = await db.send(new QueryCommand({
+      TableName: process.env.TABLE_NAME,
+      KeyConditionExpression: 'PK = :pk AND begins_with(SK, :sk)',
+      ExpressionAttributeValues: { ':pk': `GAME#${gameId}`, ':sk': 'CONNECTION#' }
+    }));
+    await Promise.all((res.Items || []).map(async (conn) => {
+      try {
+        await apigateway.send(new PostToConnectionCommand({
+          ConnectionId: conn.ConnectionId,
+          Data: JSON.stringify(message)
+        }));
+      } catch (err) {
+        // A dead projector must not stop the room being told.
+        console.error(`❌ reveal broadcast failed for ${conn.ConnectionId}:`, err.message);
+      }
+    }));
+  } catch (err) {
+    console.error('❌ reveal broadcast error:', err);
+  }
+};
+
+exports.handler = async (event) => {
+  const { gameId } = event.pathParameters || {};
+  const { questionNumber } = JSON.parse(event.body || '{}');
+
+  if (!gameId || questionNumber === undefined || questionNumber === null) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'gameId and questionNumber are required' }),
+      headers: { 'Access-Control-Allow-Origin': '*' }
+    };
+  }
+
+  const padded = String(questionNumber).padStart(3, '0');
+  const now = new Date().toISOString();
+
+  try {
+    // Idempotent by construction: an unconditional SET to true.
+    await db.send(new UpdateCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: { PK: `GAME#${gameId}`, SK: `ROUND#${padded}` },
+      UpdateExpression: 'SET #revealed = :true, #updatedAt = :now, #qn = :qn',
+      ExpressionAttributeNames: {
+        '#revealed': 'AuthorsRevealed', '#updatedAt': 'UpdatedAt', '#qn': 'QuestionNumber'
+      },
+      ExpressionAttributeValues: { ':true': true, ':now': now, ':qn': padded }
+    }));
+
+    const answersRes = await db.send(new QueryCommand({
+      TableName: process.env.TABLE_NAME,
+      KeyConditionExpression: 'PK = :pk AND begins_with(SK, :sk)',
+      ExpressionAttributeValues: {
+        ':pk': `GAME#${gameId}`, ':sk': `QUESTION#${padded}#ANSWER#`
+      }
+    }));
+
+    // Same order as the ballot — this is the query the ballot was built from.
+    const answers = (answersRes.Items || []).map(a => ({
+      playerId: a.PlayerName,
+      playerName: a.PlayerName,
+      name: a.PlayerName,
+      answer: a.Answer,
+      submittedAt: a.SubmittedAt
+    }));
+
+    await broadcastToGame(gameId, {
+      type: 'authorsRevealed',
+      gameId,
+      questionNumber: padded,
+      timestamp: now
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ status: 'OK', gameId, questionNumber: padded, answers }),
+      headers: { 'Access-Control-Allow-Origin': '*' }
+    };
+  } catch (error) {
+    console.error('❌ Reveal authors error:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to reveal authors' }),
+      headers: { 'Access-Control-Allow-Origin': '*' }
+    };
+  }
+};

--- a/lambda-functions/game/reveal-authors.js
+++ b/lambda-functions/game/reveal-authors.js
@@ -1,11 +1,14 @@
 /**
  * End the anonymity of one round.
  *
- * The reveal is the primary action of RESULTS, not an automatic consequence of
- * arriving there (§5.6.4) — so this is an endpoint the host calls, and the beat
- * order is RESULTS (anonymous) -> RESULTS (revealed) -> What we heard -> Next.
- * A host cannot forget to reveal, because revealing is the only way forward.
+ * AMENDED 2026-08-09, alongside Task 8: AuthorsRevealed now flips automatically
+ * when the round enters RESULTS (get-results.js's enterResultsState), so a host
+ * cannot fail to reveal — it is no longer a gate. This endpoint is only
+ * load-bearing for a host who reveals BEFORE closing the vote, i.e. from ASK#
+ * or VOTE#; by the time RESULTS is showing, the round is already revealed and a
+ * call here is a harmless, idempotent no-op that returns the attributed rows.
  *
+
  * PER ROUND, NOT PER GAME. A host may reveal round 3 and end the session before
  * round 4, and round 4 must stay anonymous forever in the report.
  *

--- a/lambda-functions/websocket/anonymity.js
+++ b/lambda-functions/websocket/anonymity.js
@@ -25,11 +25,38 @@
 const ANON_FIELDS = ['playerId', 'playerName', 'name'];
 
 /**
+ * Formats whose round never opens a vote.
+ *
+ * INLINED ON PURPOSE. The canonical vocabulary lives in game-types.js, and the
+ * host's runtime answer lives in src/src/config/hostControls.js
+ * (`hostRunsVotePhase`) — but this file must stay byte-identical across
+ * lambda-functions/game/ and lambda-functions/websocket/, and game-types.js
+ * exists only in the former. A require() that resolves in one bundle and not
+ * the other is worse than a duplicated four-element set.
+ * tests/anonymity-contract.js asserts this set still agrees with game-types.js
+ * for every spelling the table can hold, aliases included.
+ */
+const TYPES_THAT_SKIP_VOTE = new Set(['trivia', 'wavelength', 'quiz']);
+
+function skipsVote(gameType) {
+  return TYPES_THAT_SKIP_VOTE.has(String(gameType || '').trim().toLowerCase());
+}
+
+/**
  * @param {object} metadata the GAME#id / METADATA item
  * @param {object} round    the round record carrying AuthorsRevealed
  * @returns {boolean} true when attribution must be withheld
  */
 function isHidden(metadata, round) {
+  // Anonymity binds only the formats that hold a vote. Trivia's response is a
+  // letter, so there is nothing authored to attribute — and redacting it breaks
+  // the host's view of who answered what. Wavelength never attributes on stage.
+  //
+  // This check is not cosmetic. The flag defaults ON, and every game created
+  // before this feature has no HostPreferences at all, so without it every
+  // legacy trivia and wavelength game is silently redacted.
+  if (skipsVote(metadata && metadata.GameType)) return false;
+
   const prefs = (metadata && metadata.HostPreferences) || {};
   const anonymous = prefs.anonymousUntilReveal !== false; // default ON
   const revealed = !!(round && round.AuthorsRevealed);

--- a/lambda-functions/websocket/create-game.js
+++ b/lambda-functions/websocket/create-game.js
@@ -6,7 +6,7 @@ exports.handler = async (event) => {
   // and silently discarded that way. If you add a field to the create payload,
   // it needs THREE edits — here, the createGame() argument below, and the
   // METADATA item in schema-compliant-manager.js.
-  const { eventTitle, engagementInfo, aiContext, gameType, questionSetId, questionSetVersion, randomizeQuestions, selectedCategories, hostName, visibility, accessCode, personaId } = JSON.parse(event.body || '{}');
+  const { eventTitle, engagementInfo, aiContext, gameType, questionSetId, questionSetVersion, randomizeQuestions, anonymousUntilReveal, selectedCategories, hostName, visibility, accessCode, personaId } = JSON.parse(event.body || '{}');
 
   // Generate a unique 4-digit game ID
   const gameId = Math.floor(1000 + Math.random() * 9000).toString();
@@ -25,7 +25,10 @@ exports.handler = async (event) => {
       questionSetVersion: questionSetVersion,
       selectedCategories: selectedCategories || [],
       hostPreferences: {
-        randomizeQuestions: randomizeQuestions !== false // Default to true if not specified
+        randomizeQuestions: randomizeQuestions !== false, // Default to true if not specified
+        // Default ON, per the owner: a host who never touches setup still gets
+        // an anonymous round. Only an explicit false opts out.
+        anonymousUntilReveal: anonymousUntilReveal !== false
       },
       aiContext: aiContext,
       // The host's voice pick. Empty means "adapt to the session" — the

--- a/lambda-functions/websocket/message.js
+++ b/lambda-functions/websocket/message.js
@@ -2,6 +2,7 @@ const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient, QueryCommand, DeleteCommand, PutCommand, GetCommand, UpdateCommand } = require('@aws-sdk/lib-dynamodb');
 const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require('@aws-sdk/client-apigatewaymanagementapi');
 const { resolveSetPartition } = require('./set-version');
+const { isHidden } = require('./anonymity');
 
 const dynamoClient = new DynamoDBClient({});
 const db = DynamoDBDocumentClient.from(dynamoClient);
@@ -579,6 +580,37 @@ async function handlePlayerMessage(gameId, playerName, messageType, messageData)
         const questionNumber = messageType.replace('ANSWER#', '');
         notificationData.questionNumber = questionNumber;
         notificationData.questionId = questionNumber; // For backward compatibility
+
+        // ANONYMITY. This frame is the one leak a purely HTTP redaction would
+        // leave behind: it hands the host's socket a live author-to-answer
+        // mapping the moment an answer lands, before any endpoint is called.
+        // Under §5.6.2 the host is inside "nobody", so while hidden we announce
+        // only THAT an answer arrived and which round it belongs to.
+        //
+        // The host still needs the count to know whether it can move on, and
+        // the count is not attribution — see §5.6.2's split between "who has
+        // not acted" and "who wrote which answer".
+        const [metaRes, roundRes] = await Promise.all([
+          db.send(new GetCommand({
+            TableName: process.env.TABLE_NAME,
+            Key: { PK: `GAME#${gameId}`, SK: 'METADATA' }
+          })),
+          db.send(new GetCommand({
+            TableName: process.env.TABLE_NAME,
+            Key: { PK: `GAME#${gameId}`, SK: `ROUND#${questionNumber}` }
+          }))
+        ]);
+
+        if (isHidden(metaRes.Item, roundRes.Item)) {
+          notificationData = {
+            messageType,
+            gameId,
+            questionNumber,
+            questionId: questionNumber,
+            timestamp: new Date().toISOString()
+          };
+        }
+
         console.log(`🔔 Preparing playerAnswered notification: questionNumber=${questionNumber}, playerName=${playerName}`);
       } else if (messageType.startsWith('VOTE#')) {
         notificationType = 'playerVoted';

--- a/lambda-functions/websocket/message.js
+++ b/lambda-functions/websocket/message.js
@@ -595,9 +595,15 @@ async function handlePlayerMessage(gameId, playerName, messageType, messageData)
             TableName: process.env.TABLE_NAME,
             Key: { PK: `GAME#${gameId}`, SK: 'METADATA' }
           })),
+          // ROUND# keys are always stored zero-padded to 3 digits (see
+          // handlePlayerAnswer's own `questionNumber` a few hundred lines up,
+          // and start-vote.js / reveal-authors.js) — an unpadded lookup here
+          // (e.g. from messageType 'ANSWER#1') misses the row entirely. It
+          // fails safe today (isHidden(meta, undefined) still returns hidden),
+          // but that's an accident of the default, not a reason to skip padding.
           db.send(new GetCommand({
             TableName: process.env.TABLE_NAME,
-            Key: { PK: `GAME#${gameId}`, SK: `ROUND#${questionNumber}` }
+            Key: { PK: `GAME#${gameId}`, SK: `ROUND#${String(questionNumber).padStart(3, '0')}` }
           }))
         ]);
 

--- a/lambda-functions/websocket/schema-compliant-manager.js
+++ b/lambda-functions/websocket/schema-compliant-manager.js
@@ -96,6 +96,16 @@ const createGame = async (gameId, gameData) => {
           thirdPlacePoints: gameData.scoring?.thirdPlacePoints || 1,
           participationPoints: gameData.scoring?.participationPoints || 0
         },
+        // The host's setup choices. Read by the anonymity gate on every answer
+        // payload; `randomizeQuestions` is read at :264 for question selection.
+        // This is the third of the three edits create-game.js warns about —
+        // destructure, createGame() argument, and here. Miss this one and the
+        // field is accepted by the API and silently discarded, which is what
+        // happened to triviaTimer.
+        HostPreferences: {
+          randomizeQuestions: gameData.hostPreferences?.randomizeQuestions !== false,
+          anonymousUntilReveal: gameData.hostPreferences?.anonymousUntilReveal !== false
+        },
         ttl
       }
     }));

--- a/lambda-functions/websocket/start-vote.js
+++ b/lambda-functions/websocket/start-vote.js
@@ -1,6 +1,7 @@
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
-const { DynamoDBDocumentClient, QueryCommand, UpdateCommand } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDBDocumentClient, GetCommand, QueryCommand, UpdateCommand } = require('@aws-sdk/lib-dynamodb');
 const { broadcastToGame } = require('./schema-compliant-manager');
+const { isHidden, redactAnswers } = require('./anonymity');
 
 const client = new DynamoDBClient({});
 const db = DynamoDBDocumentClient.from(client);
@@ -44,6 +45,29 @@ exports.handler = async (event) => {
     const answers = answersResult.Items || [];
     console.log(`🗳️ Found ${answers.length} answers for question ${paddedQuestionNumber}`);
 
+    // Anonymity gate. The answers travel over HTTP, which is where the
+    // redaction belongs — the votingStarted broadcast below carries no
+    // attribution and never has.
+    const [metaRes, roundRes] = await Promise.all([
+      db.send(new GetCommand({
+        TableName: process.env.TABLE_NAME,
+        Key: { PK: `GAME#${gameId}`, SK: 'METADATA' }
+      })),
+      db.send(new GetCommand({
+        TableName: process.env.TABLE_NAME,
+        Key: { PK: `GAME#${gameId}`, SK: `ROUND#${paddedQuestionNumber}` }
+      }))
+    ]);
+    const hidden = isHidden(metaRes.Item, roundRes.Item);
+
+    const ballot = answers.map(answer => ({
+      playerId: answer.PlayerName,
+      playerName: answer.PlayerName,
+      name: answer.PlayerName, // Add name field for frontend compatibility
+      answer: answer.Answer,
+      submittedAt: answer.SubmittedAt
+    }));
+
     // Broadcast voting started to everyone attached to the game, host included.
     //
     // `newState` is not decoration. GameHostPage's votingStarted handler reads
@@ -70,13 +94,7 @@ exports.handler = async (event) => {
         status: 'OK',
         questionNumber: questionNumber,
         newState: newState,
-        answers: answers.map(answer => ({
-          playerId: answer.PlayerName,
-          playerName: answer.PlayerName,
-          name: answer.PlayerName, // Add name field for frontend compatibility
-          answer: answer.Answer,
-          submittedAt: answer.SubmittedAt
-        }))
+        answers: hidden ? redactAnswers(ballot) : ballot
       }),
       headers: { 'Access-Control-Allow-Origin': '*' }
     };

--- a/src/src/GameHostPage.jsx
+++ b/src/src/GameHostPage.jsx
@@ -16,6 +16,7 @@ import {
 import { resetGameSession } from './config/gameSession';
 import { gameTypeMeta } from './config/gameTypes';
 import { hostControlsFor, phaseOfGameState, HOST_INTENTS } from './config/hostControls';
+import { anonymityApplies, createPayloadFor } from './config/anonymity';
 import { useAuth } from './auth/AuthContext';
 import { authFetch } from './auth/authFetch';
 
@@ -142,6 +143,7 @@ function GameHostPage() {
   const [engagementType, setEngagementType] = useState('call-and-answer'); // 'call-and-answer', 'trivia', or 'wavelength'
   const [triviaTimer, setTriviaTimer] = useState(30); // Timer for trivia questions in seconds
   const [randomizeQuestions, setRandomizeQuestions] = useState(true); // Default ON - randomize question order
+  const [anonymousResponses, setAnonymousResponses] = useState(true); // Default ON - hide authorship until the round reveals
 
   // Workie's voice. '' means "adapt to the session" — the designed default, and
   // deliberately NOT the legacy prompt template's baked-in persona. See
@@ -2445,7 +2447,8 @@ Focus on actionable business strategy insights.`;
           // '' means "adapt to the session". create-game.js only stores
           // PersonaId when this is non-empty.
           personaId: newGamePersonaId || '',
-          hostName: 'Host'
+          hostName: 'Host',
+          ...createPayloadFor({ gameType: engagementType, anonymousResponses }),
         })
       });
 
@@ -3197,6 +3200,35 @@ Ready to engage? See you there!`;
                 }
               </small>
             </div>
+
+            {/* Checked against `engagementType` — this dialog's own type
+                picker — not `currentGameType`, which still names whatever
+                game is on screen until this new one is created. */}
+            {anonymityApplies(engagementType) && (
+              <div className="setup-section">
+                <h3>Responses</h3>
+                <label className="setup-toggle">
+                  <input
+                    type="checkbox"
+                    checked={anonymousResponses}
+                    onChange={(e) => setAnonymousResponses(e.target.checked)}
+                  />
+                  <span className="setup-toggle-label">Anonymous responses</span>
+                </label>
+                {/* Default ON, so this copy has to make an ALREADY-ACTIVE guarantee legible
+                    to a host who never touches it. The second clause is the surprising one,
+                    so it is stated rather than implied. */}
+                <p className="setup-help">
+                  Until voting closes, nobody sees who wrote which answer — not the room,
+                  not you. The room votes on the answers, not on the people.
+                </p>
+                <p className="setup-help setup-help--muted">
+                  {anonymousResponses
+                    ? 'This hides names, not identities. In a small group, people may still recognise each other’s answers.'
+                    : 'Every answer is labelled with its author from the moment voting opens.'}
+                </p>
+              </div>
+            )}
 
             <div className="form-group">
               <label>AI Context (Optional):</label>

--- a/src/src/GameHostPage.jsx
+++ b/src/src/GameHostPage.jsx
@@ -16,7 +16,7 @@ import {
 import { resetGameSession } from './config/gameSession';
 import { gameTypeMeta } from './config/gameTypes';
 import { hostControlsFor, phaseOfGameState, HOST_INTENTS } from './config/hostControls';
-import { anonymityApplies, createPayloadFor } from './config/anonymity';
+import { anonymityApplies, createPayloadFor, displayLabelFor, standingsVisible } from './config/anonymity';
 import { useAuth } from './auth/AuthContext';
 import { authFetch } from './auth/authFetch';
 
@@ -95,7 +95,12 @@ function GameHostPage() {
   const [showReport, setShowReport] = useState(false);
   const [reportData, setReportData] = useState(null);
   const [lessonNumber, setLessonNumber] = useState(0);
-  
+  // Whether this round's authors are showing. AuthorsRevealed flips
+  // automatically when the round enters RESULTS (get-results.js's
+  // enterResultsState), so this is mostly a display step; handleRevealAuthors
+  // below is the override for a host who wants names back before that.
+  const [authorsRevealed, setAuthorsRevealed] = useState(false);
+
   // Custom instruction state for question set instructions
   const [customInstruction, setCustomInstruction] = useState(null);
   const [setRoundNoun, setSetRoundNoun] = useState(null); // per-set override, e.g. "Lesson"
@@ -302,6 +307,7 @@ function GameHostPage() {
     currentQuestionId: setCurrentQuestionId,
     currentQuestionIndex: setCurrentQuestionIndex,
     lessonNumber: setLessonNumber,
+    authorsRevealed: setAuthorsRevealed,
     players: setPlayers,
     answers: setAnswers,
     playersWhoAnswered: setPlayersWhoAnswered,
@@ -923,6 +929,13 @@ Focus on actionable business strategy insights.`;
       restoreGameState();
     });
 
+    webSocketClient.onMessage('authorsRevealed', (data) => {
+      console.log('🔌 Authors revealed notification:', data);
+      // Re-sync rather than patching state, exactly like questionStarted and
+      // gameStateChanged. The attributed rows come back from the API.
+      restoreGameState();
+    });
+
     webSocketClient.onMessage('aiSummaryReady', (data) => {
       console.log('🔌 AI Summary ready notification:', data);
       if (aiWatchdogRef.current) clearTimeout(aiWatchdogRef.current);
@@ -999,6 +1012,7 @@ Focus on actionable business strategy insights.`;
       webSocketClient.offMessage('playerAnswered');
       webSocketClient.offMessage('playerVoted');
       webSocketClient.offMessage('votingStarted');
+      webSocketClient.offMessage('authorsRevealed');
       webSocketClient.offMessage('aiSummaryReady');
       webSocketClient.offMessage('aiSummaryError');
     };
@@ -1113,6 +1127,16 @@ Focus on actionable business strategy insights.`;
         // Use server state directly instead of mapping to legacy format
         setGameState(currentState);
         console.log(`🎮 HOST: Set game state to ${currentState}`);
+
+        // The round record itself, for this purpose, IS the state string:
+        // enterResultsState (get-results.js) sets AuthorsRevealed unconditionally
+        // the moment a round enters RESULTS#, so "in RESULTS" and "revealed" are
+        // the same fact by the time a host is looking at this screen. ASK#/VOTE#
+        // always restore to not-revealed, which is also correct for a host who
+        // revealed early and then refreshed — the durable ROUND# record still
+        // says revealed, but re-fetching it here would need a second round-trip
+        // this screen doesn't otherwise make; re-revealing costs one tap.
+        setAuthorsRevealed(currentState.startsWith('RESULTS#'));
         console.log(`🔍 HOST: Questions array length: ${questions.length}`);
         
         // If we have a current question, set it up
@@ -1222,6 +1246,7 @@ Focus on actionable business strategy insights.`;
                   
                   formattedAnswers = (resultsData.answers || []).map(answer => ({
                     player: answer.playerName,
+                    playerName: answer.playerName, // for displayLabelFor
                     answer: answer.answer, // Letter like 'A', 'B', 'C'
                     points: answer.pointsEarned || 0,
                     isCorrect: answer.isCorrect || false,
@@ -1238,6 +1263,7 @@ Focus on actionable business strategy insights.`;
                         console.log(`📊 HOST: Formatting tally ${index}:`, tally);
                         return {
                           player: tally.playerName,
+                          playerName: tally.playerName, // for displayLabelFor
                           answer: tally.answerText,
                           points: tally.totalScore,
                           placement: tally.firstPlace > 0 ? 1 : tally.secondPlace > 0 ? 2 : tally.thirdPlace > 0 ? 3 : 0,
@@ -1720,7 +1746,8 @@ Focus on actionable business strategy insights.`;
       setGameState(newState);
       setQuestions([questionData]);
       setLessonNumber(lessonNumber);
-      
+      setAuthorsRevealed(false); // A new round starts anonymous, not the last one's reveal
+
       // Notify players via WebSocket (exactly like handleNextQuestion)
       if (webSocketClient.isConnected()) {
         const messageType = newState;
@@ -1913,6 +1940,7 @@ Focus on actionable business strategy insights.`;
       setCurrentQuestionVotes([]);
       setCurrentAnswerIndex(0);
       setLessonNumber(lessonNumber);
+      setAuthorsRevealed(false); // A new round starts anonymous, not the last one's reveal
       setCurrentQuestionId(questionId);
       
       // Set the questions array
@@ -2148,6 +2176,7 @@ Focus on actionable business strategy insights.`;
         
         formattedAnswers = (resultsData.answers || []).map(answer => ({
           player: answer.playerName,
+          playerName: answer.playerName, // for displayLabelFor
           answer: answer.answer, // Letter like 'A', 'B', 'C'
           points: answer.pointsEarned || 0,
           isCorrect: answer.isCorrect || false,
@@ -2156,30 +2185,32 @@ Focus on actionable business strategy insights.`;
           basePoints: answer.basePoints || 0,
           submittedAt: answer.submittedAt
         }));
-        
-        console.log(`🧠 HOST: Formatted ${formattedAnswers.length} trivia answers:`, 
+
+        console.log(`🧠 HOST: Formatted ${formattedAnswers.length} trivia answers:`,
           formattedAnswers.map(a => `${a.player}: ${a.answer} (${a.isCorrect ? 'correct' : 'incorrect'}, ${a.points} pts)`));
-        
+
       } else if (resultsData.gameType === 'wavelength' || currentGameType === 'wavelength') {
         // Wavelength results format: Just the raw answers with words
         console.log(`🌊 HOST: Processing wavelength results with ${resultsData.answers?.length || 0} answers`);
-        
+
         formattedAnswers = (resultsData.answers || []).map(answer => ({
           player: answer.playerName,
+          playerName: answer.playerName, // for displayLabelFor
           answer: answer.answer || answer.ProcessedWords?.join(',') || '', // Comma-separated words
           points: 0, // No points in wavelength
           submittedAt: answer.submittedAt
         }));
-        
+
         console.log(`🌊 HOST: Formatted ${formattedAnswers.length} wavelength answers for word cloud`);
-        
+
       } else {
         // Call-and-answer results format: { voteTallies: {...} }
         console.log(`💬 HOST: Processing call-and-answer results with voteTallies`);
-        
+
         formattedAnswers = resultsData.voteTallies && Object.keys(resultsData.voteTallies).length > 0
           ? Object.values(resultsData.voteTallies).map(tally => ({
               player: tally.playerName,
+              playerName: tally.playerName, // for displayLabelFor
               answer: tally.answerText,
               points: tally.totalScore,
               placement: tally.firstPlace > 0 ? 1 : tally.secondPlace > 0 ? 2 : tally.thirdPlace > 0 ? 3 : 0,
@@ -2249,6 +2280,32 @@ Focus on actionable business strategy insights.`;
     } finally {
       // Hide loading overlay
       setIsLoadingData(false);
+    }
+  };
+
+  // Display step, plus an override. AuthorsRevealed flips when voting closes
+  // (get-results.js:enterResultsState), so this endpoint is only load-bearing
+  // when the host reveals BEFORE closing the vote. Calling it when the round is
+  // already revealed is a harmless no-op — the endpoint is idempotent — but
+  // there is nothing to fetch, so skip the round-trip and leave the display as
+  // is. `‹ Hide again` is the separate, purely-local toggle back to hidden.
+  const handleRevealAuthors = async () => {
+    if (authorsRevealed) return;
+    try {
+      const res = await fetch(`${API_BASE}games/${gameId}/reveal-authors`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ questionNumber: lessonNumber })
+      });
+      if (!res.ok) {
+        console.error('❌ HOST: reveal failed:', res.status);
+        return;
+      }
+      const data = await res.json();
+      setAnswers(data.answers || []);
+      setAuthorsRevealed(true);
+    } catch (e) {
+      console.error('❌ HOST: reveal error', e);
     }
   };
 
@@ -3802,7 +3859,13 @@ Ready to engage? See you there!`;
                 <div className="player-name">
                   {rankIcon} <span className="player-name-text">{player.name || player.playerName || 'Unknown Player'}</span>
                 </div>
-                <div className="player-score">{score} pts</div>
+                {/* Attribution by arithmetic (see config/anonymity.js: standingsVisible):
+                    withheld while an anonymous round is unrevealed, because a
+                    score jumping here identifies the author of that round's
+                    top-scoring answer as surely as a name would. */}
+                {standingsVisible({ gameType: currentGameType, authorsRevealed }) && (
+                  <div className="player-score">{score} pts</div>
+                )}
                 {gameState.startsWith('ASK#') && (
                   <div className={`answer-status ${playersWhoAnswered.includes(player.name) ? 'answered' : 'waiting'}`}>
                     {playersWhoAnswered.includes(player.name)
@@ -4008,7 +4071,7 @@ Ready to engage? See you there!`;
                   
                   <div className="single-answer-display">
                     <div className="answer-text">"{answers[currentAnswerIndex]?.answer}"</div>
-                    <div className="answer-author">- {answers[currentAnswerIndex]?.name}</div>
+                    <div className="answer-author">- {displayLabelFor(answers[currentAnswerIndex] || {}, currentAnswerIndex)}</div>
                   </div>
                   
                   <button 
@@ -4034,7 +4097,21 @@ Ready to engage? See you there!`;
               <Icon name="Trophy" weight="duotone" size={30} color="var(--primary)" />
               <span>{getHostRoundNoun()} {parseInt(gameState.split('#')[1])} · Results</span>
             </h2>
-            
+
+            {/* Only formats that held a vote have anything to reveal — an option
+                that cannot do anything is a question a host should not be asked. */}
+            {anonymityApplies(currentGameType) && (
+              authorsRevealed ? (
+                <button className="ghost-step-back" onClick={() => setAuthorsRevealed(false)}>
+                  ‹ Hide again
+                </button>
+              ) : (
+                <button className="reveal-authors-btn" onClick={handleRevealAuthors}>
+                  Reveal Authors
+                </button>
+              )
+            )}
+
             {currentGameType === 'trivia' ? (
               <div className="trivia-results-display">
                 <div className="trivia-question-recap">
@@ -4117,15 +4194,16 @@ Ready to engage? See you there!`;
                   {answers.map((answer, idx) => {
                     // Use the already calculated data from the API instead of recalculating
                     const playerName = answer.player; // Correct property name for trivia results
+                    const displayName = displayLabelFor(answer, idx); // trivia never redacts, so this is always playerName
                     const isCorrect = answer.isCorrect; // From API calculation
                     const roundPoints = answer.points || 0; // From API calculation (includes speed bonus)
                     const player = players.find(p => p.name === playerName);
-                    
+
                     console.log(`🏆 TRIVIA PLAYER RESULT: ${playerName} answered ${answer.answer}, isCorrect: ${isCorrect}, points: ${roundPoints}, total: ${player?.score}`);
-                    
+
                     return (
                       <div key={idx} className={`trivia-player-result ${isCorrect ? 'correct' : 'incorrect'}`}>
-                        <span className="player-name">{playerName}</span>
+                        <span className="player-name">{displayName}</span>
                         <span className="player-answer">Answer: {answer.answer}</span>
                         <span className="player-points">
                           {isCorrect
@@ -4154,11 +4232,12 @@ Ready to engage? See you there!`;
                     {answers.map((answer, idx) => {
                       const player = players.find(p => p.name === answer.player);
                       const playerTotalScore = player?.score || 0;
-                      
+                      const displayName = displayLabelFor(answer, idx); // wavelength never redacts, so this is always the name
+
                       return (
                         <div key={idx} className="result-item wavelength-contribution">
                           <div className="result-player-header">
-                            <div className="result-player-name">{answer.player}</div>
+                            <div className="result-player-name">{displayName}</div>
                             <div className="result-points">
                               <span className="points-total">Score: {playerTotalScore} pts</span>
                             </div>
@@ -4196,11 +4275,12 @@ Ready to engage? See you there!`;
                 console.log(`🧮 This means previous score was: ${playerTotalScore - totalPoints}`);
                 
                 const previousScore = playerTotalScore - totalPoints;
-                
+                const displayName = displayLabelFor(answer, idx);
+
                 return (
                   <div key={idx} className={`result-item ${totalPoints > 0 ? 'scored' : ''}`}>
                     <div className="result-player-header">
-                      <div className="result-player-name">{answer.player}</div>
+                      <div className="result-player-name">{displayName}</div>
                       <div className="result-points">
                         <span className="points-this-round">+{totalPoints} pts this round</span>
                         <span className="points-total">Total: {playerTotalScore} pts</span>

--- a/src/src/__tests__/anonymitySetup.test.js
+++ b/src/src/__tests__/anonymitySetup.test.js
@@ -7,7 +7,9 @@
  * the option at all, and what the create payload carries.
  */
 import { hostRunsVotePhase } from '../config/hostControls';
-import { anonymityApplies, createPayloadFor } from '../config/anonymity';
+import {
+  anonymityApplies, createPayloadFor, displayLabelFor, isRedacted, standingsVisible,
+} from '../config/anonymity';
 
 describe('which formats offer anonymous responses', () => {
   // Not a new taxonomy — exactly the set that holds a vote.
@@ -44,5 +46,45 @@ describe('the create payload', () => {
   test('a non-voting type sends false explicitly, not undefined', () => {
     const payload = createPayloadFor({ gameType: 'trivia' });
     expect(payload.anonymousUntilReveal).toBe(false);
+  });
+});
+
+describe('how an answer is labelled', () => {
+  const anon = { answer: 'a splendid answer' };
+  const named = { playerName: 'Ada', answer: 'a splendid answer' };
+
+  test('a redacted row is labelled by position, 1-based', () => {
+    expect(displayLabelFor(anon, 0)).toBe('Response 1');
+    expect(displayLabelFor(anon, 2)).toBe('Response 3');
+  });
+
+  test('an attributed row is labelled by name', () => {
+    expect(displayLabelFor(named, 0)).toBe('Ada');
+  });
+
+  // Omit-not-null is the backend contract; this is the client half of it.
+  test('the absence of playerName is what marks a row redacted', () => {
+    expect(isRedacted(anon)).toBe(true);
+    expect(isRedacted(named)).toBe(false);
+  });
+
+  test('a literal null never renders as the string "null"', () => {
+    expect(displayLabelFor({ playerName: null, answer: 'x' }, 0)).toBe('Response 1');
+  });
+
+  test('an empty-string name is treated as redacted, not as a blank label', () => {
+    expect(displayLabelFor({ playerName: '', answer: 'x' }, 1)).toBe('Response 2');
+  });
+});
+
+describe('standings before the reveal', () => {
+  test('hidden while an anonymous round is unrevealed', () => {
+    expect(standingsVisible({ gameType: 'call-and-answer', authorsRevealed: false })).toBe(false);
+  });
+  test('shown once revealed', () => {
+    expect(standingsVisible({ gameType: 'call-and-answer', authorsRevealed: true })).toBe(true);
+  });
+  test('always shown for a format with no anonymity', () => {
+    expect(standingsVisible({ gameType: 'trivia', authorsRevealed: false })).toBe(true);
   });
 });

--- a/src/src/__tests__/anonymitySetup.test.js
+++ b/src/src/__tests__/anonymitySetup.test.js
@@ -1,0 +1,48 @@
+/**
+ * The setup control's *decisions*, tested as pure logic.
+ *
+ * Rendering GameHostPage in jsdom currently fails on the auth provider (see the
+ * five stale suites in the handoff), so this asserts the two rules that matter
+ * and that a component test would otherwise re-derive: which game types offer
+ * the option at all, and what the create payload carries.
+ */
+import { hostRunsVotePhase } from '../config/hostControls';
+import { anonymityApplies, createPayloadFor } from '../config/anonymity';
+
+describe('which formats offer anonymous responses', () => {
+  // Not a new taxonomy — exactly the set that holds a vote.
+  test.each(['call-and-answer', 'poll', 'survey'])('%s offers it', (type) => {
+    expect(anonymityApplies(type)).toBe(true);
+  });
+
+  // An option that cannot do anything is a question a host should not be asked,
+  // so these hide it rather than showing it disabled.
+  test.each(['trivia', 'wavelength'])('%s hides it', (type) => {
+    expect(anonymityApplies(type)).toBe(false);
+  });
+
+  test('it tracks hostRunsVotePhase rather than a second list', () => {
+    for (const t of ['call-and-answer', 'poll', 'survey', 'trivia', 'wavelength']) {
+      expect(anonymityApplies(t)).toBe(hostRunsVotePhase(t));
+    }
+  });
+});
+
+describe('the create payload', () => {
+  test('defaults to anonymous when the host never touches setup', () => {
+    expect(createPayloadFor({ gameType: 'call-and-answer' }).anonymousUntilReveal).toBe(true);
+  });
+
+  test('carries an explicit opt-out', () => {
+    expect(createPayloadFor({ gameType: 'call-and-answer', anonymousResponses: false })
+      .anonymousUntilReveal).toBe(false);
+  });
+
+  // The backend defaults ON for any value that is not exactly false, so a
+  // non-voting type must send `false` explicitly rather than omitting the key —
+  // otherwise a trivia game is silently "anonymous" with nothing to anonymise.
+  test('a non-voting type sends false explicitly, not undefined', () => {
+    const payload = createPayloadFor({ gameType: 'trivia' });
+    expect(payload.anonymousUntilReveal).toBe(false);
+  });
+});

--- a/src/src/config/anonymity.js
+++ b/src/src/config/anonymity.js
@@ -1,0 +1,35 @@
+/**
+ * Which sessions offer anonymous responses, and what setup sends.
+ *
+ * Kept out of GameHostPage because these are two decisions worth reading on
+ * their own, and because that file is 5000 lines.
+ */
+import { hostRunsVotePhase } from './hostControls';
+
+/**
+ * Anonymity applies exactly to the formats that hold a vote — call-and-answer,
+ * poll, survey. That is not a new taxonomy: hostRunsVotePhase already computes
+ * this set, and deriving from it means the two cannot drift.
+ *
+ * Trivia's response is a letter, so there is nothing authored to attribute;
+ * wavelength never attributes on the stage. For those the option is hidden
+ * rather than shown-and-disabled, because an option that cannot do anything is
+ * a question a host should not be asked.
+ */
+export function anonymityApplies(gameType) {
+  return hostRunsVotePhase(gameType);
+}
+
+/**
+ * The anonymity part of the create payload.
+ *
+ * Sends `false` EXPLICITLY for non-voting types rather than omitting the key.
+ * The backend gate defaults ON for anything that is not exactly `false`, so an
+ * omitted key would mark a trivia game anonymous with nothing to anonymise —
+ * harmless today, confusing in a payload diff, and a trap if trivia ever gains
+ * a free-text round.
+ */
+export function createPayloadFor({ gameType, anonymousResponses } = {}) {
+  if (!anonymityApplies(gameType)) return { anonymousUntilReveal: false };
+  return { anonymousUntilReveal: anonymousResponses !== false };
+}

--- a/src/src/config/anonymity.js
+++ b/src/src/config/anonymity.js
@@ -33,3 +33,28 @@ export function createPayloadFor({ gameType, anonymousResponses } = {}) {
   if (!anonymityApplies(gameType)) return { anonymousUntilReveal: false };
   return { anonymousUntilReveal: anonymousResponses !== false };
 }
+
+/**
+ * A row is redacted when it has no usable author, which is the client half of
+ * the backend's omit-don't-null rule. Treats null and '' as redacted too, so a
+ * partial payload can never render an empty label or the string "null".
+ */
+export function isRedacted(answer) {
+  return !(answer && typeof answer.playerName === 'string' && answer.playerName.length > 0);
+}
+
+/**
+ * What to print above an answer. `Response N` is 1-based because it is read
+ * aloud in a room — "look at response three", not "response two".
+ */
+export function displayLabelFor(answer, index) {
+  return isRedacted(answer) ? `Response ${index + 1}` : answer.playerName;
+}
+
+/**
+ * Whether standings may be shown. See §5.6.4: a live leaderboard during an
+ * anonymous round is attribution by arithmetic, so it waits for the reveal.
+ */
+export function standingsVisible({ gameType, authorsRevealed } = {}) {
+  return !anonymityApplies(gameType) || authorsRevealed === true;
+}

--- a/src/src/config/gameSession.js
+++ b/src/src/config/gameSession.js
@@ -55,6 +55,9 @@ export function initialGameSession() {
     currentQuestionId: '',
     currentQuestionIndex: -1,
     lessonNumber: 0,
+    // Whether the round in play has shown its authors. Round-scoped, exactly
+    // like lessonNumber — a new game must not inherit the last one's reveal.
+    authorsRevealed: false,
 
     // --- the room ------------------------------------------------------
     players: [],

--- a/template-clean.yaml
+++ b/template-clean.yaml
@@ -276,6 +276,31 @@ Resources:
         Environment: !Ref Environment
         StackName: !Ref StackName
 
+  RevealAuthorsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub '${StackName}-reveal-authors'
+      CodeUri: lambda-functions/game/
+      Handler: reveal-authors.handler
+      Events:
+        RevealAuthors:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref RestApi
+            Path: /games/{gameId}/reveal-authors
+            Method: post
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref GameTable
+        - Statement:
+          - Effect: Allow
+            Action:
+              - execute-api:ManageConnections
+            Resource: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*/*'
+      Tags:
+        Environment: !Ref Environment
+        StackName: !Ref StackName
+
   ### HTTP API with Simple Naming (like original GameApi)
   RestApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/anonymity-contract.js
+++ b/tests/anonymity-contract.js
@@ -22,8 +22,8 @@ const WS_COPY = path.join(REPO, 'lambda-functions/websocket/anonymity.js');
 const { isHidden, redactAnswer, redactAnswers, ANON_FIELDS } = require(GAME_COPY);
 
 let pass = 0, fail = 0;
-function check(label, fn) {
-  try { fn(); console.log(`  PASS  ${label}`); pass++; }
+async function check(label, fn) {
+  try { await fn(); console.log(`  PASS  ${label}`); pass++; }
   catch (e) { console.log(`  FAIL  ${label}\n        ${e.message}`); fail++; }
 }
 
@@ -31,30 +31,32 @@ const on = { HostPreferences: { anonymousUntilReveal: true } };
 const off = { HostPreferences: { anonymousUntilReveal: false } };
 const bare = {};
 
+(async () => {
+
 console.log('\n1. the gate');
 
 // Default ON is the owner's explicit requirement, and it must survive every
 // shape of missing data — a game created before this feature existed has no
 // HostPreferences at all and must still be anonymous.
-check('absent preferences default to hidden', () =>
+await check('absent preferences default to hidden', () =>
   assert.strictEqual(isHidden(bare, {}), true));
-check('absent metadata entirely defaults to hidden', () =>
+await check('absent metadata entirely defaults to hidden', () =>
   assert.strictEqual(isHidden(undefined, undefined), true));
-check('explicitly on is hidden', () =>
+await check('explicitly on is hidden', () =>
   assert.strictEqual(isHidden(on, {}), true));
-check('explicitly off is never hidden', () =>
+await check('explicitly off is never hidden', () =>
   assert.strictEqual(isHidden(off, {}), false));
-check('off stays off even before reveal', () =>
+await check('off stays off even before reveal', () =>
   assert.strictEqual(isHidden(off, { AuthorsRevealed: false }), false));
 
 console.log('\n2. reveal ends it, per round');
 
-check('revealed round is not hidden', () =>
+await check('revealed round is not hidden', () =>
   assert.strictEqual(isHidden(on, { AuthorsRevealed: true }), false));
-check('an unrevealed round is still hidden', () =>
+await check('an unrevealed round is still hidden', () =>
   assert.strictEqual(isHidden(on, { AuthorsRevealed: false }), true));
 // Per-round, not per-game: revealing round 3 must not unmask round 4.
-check('reveal on another round does not leak into this one', () =>
+await check('reveal on another round does not leak into this one', () =>
   assert.strictEqual(isHidden(on, {}), true));
 
 console.log('\n3. redaction omits, never nulls');
@@ -64,20 +66,20 @@ const row = {
   answer: 'a splendid answer', answerType: 'text', submittedAt: '2026-01-01T00:00:00.000Z'
 };
 
-check('all three attribution fields are absent, not null', () => {
+await check('all three attribution fields are absent, not null', () => {
   const out = redactAnswer(row);
   for (const f of ANON_FIELDS) {
     assert.ok(!(f in out), `'${f}' is still present as ${JSON.stringify(out[f])}`);
   }
 });
-check('the answer itself survives', () =>
+await check('the answer itself survives', () =>
   assert.strictEqual(redactAnswer(row).answer, 'a splendid answer'));
-check('non-attribution fields survive', () => {
+await check('non-attribution fields survive', () => {
   const out = redactAnswer(row);
   assert.strictEqual(out.answerType, 'text');
   assert.strictEqual(out.submittedAt, '2026-01-01T00:00:00.000Z');
 });
-check('the input is not mutated', () => {
+await check('the input is not mutated', () => {
   const input = { ...row };
   redactAnswer(input);
   assert.strictEqual(input.playerName, 'Ada', 'redactAnswer mutated its argument');
@@ -91,19 +93,19 @@ const many = ['Ada', 'Grace', 'Alan', 'Barbara'].map((n, i) => ({
   playerName: n, name: n, playerId: n, answer: `answer ${i}`
 }));
 
-check('length is unchanged', () =>
+await check('length is unchanged', () =>
   assert.strictEqual(redactAnswers(many).length, 4));
-check('order is unchanged', () =>
+await check('order is unchanged', () =>
   assert.deepStrictEqual(redactAnswers(many).map(a => a.answer),
     ['answer 0', 'answer 1', 'answer 2', 'answer 3']));
-check('an empty round redacts to an empty array', () =>
+await check('an empty round redacts to an empty array', () =>
   assert.deepStrictEqual(redactAnswers([]), []));
-check('a non-array is treated as empty rather than thrown', () =>
+await check('a non-array is treated as empty rather than thrown', () =>
   assert.deepStrictEqual(redactAnswers(undefined), []));
 
 console.log('\n5. the two copies have not drifted');
 
-check('game/anonymity.js and websocket/anonymity.js are byte-identical', () => {
+await check('game/anonymity.js and websocket/anonymity.js are byte-identical', () => {
   const a = fs.readFileSync(GAME_COPY, 'utf8');
   const b = fs.readFileSync(WS_COPY, 'utf8');
   assert.strictEqual(a, b,
@@ -111,5 +113,108 @@ check('game/anonymity.js and websocket/anonymity.js are byte-identical', () => {
     'Lambda directories is a leak no single-file test can see');
 });
 
+console.log('\n6. the setup flag survives a create round-trip');
+
+// Stubs must be installed before the handler loads. Same shape as
+// tests/vote-state-broadcast.js.
+const store = new Map();
+const key = (pk, sk) => `${pk}|${sk}`;
+
+class PutCommand { constructor(i) { this.input = i; this.type = 'put'; } }
+class GetCommand { constructor(i) { this.input = i; this.type = 'get'; } }
+class QueryCommand { constructor(i) { this.input = i; this.type = 'query'; } }
+class UpdateCommand { constructor(i) { this.input = i; this.type = 'update'; } }
+class DeleteCommand { constructor(i) { this.input = i; this.type = 'delete'; } }
+
+const fakeDoc = {
+  send: async (cmd) => {
+    const inp = cmd.input || {};
+    switch (cmd.type) {
+      case 'put': store.set(key(inp.Item.PK, inp.Item.SK), inp.Item); return {};
+      case 'get': return { Item: store.get(key(inp.Key.PK, inp.Key.SK)) };
+      case 'query': {
+        const pk = inp.ExpressionAttributeValues[':pk'];
+        const prefix = inp.ExpressionAttributeValues[':sk'] ?? '';
+        const items = [...store.values()].filter(
+          (i) => i.PK === pk && String(i.SK).startsWith(String(prefix)));
+        return { Items: items, Count: items.length };
+      }
+      default: return {};
+    }
+  }
+};
+
+const STUB_PATHS = [
+  REPO,
+  path.join(REPO, 'lambda-functions'),
+  path.join(REPO, 'lambda-functions', 'game'),
+  path.join(REPO, 'lambda-functions', 'websocket'),
+];
+
+function stub(name, exports) {
+  const seen = new Set();
+  for (const base of STUB_PATHS) {
+    let p;
+    try { p = require.resolve(name, { paths: [base] }); } catch { continue; }
+    if (seen.has(p)) continue;
+    seen.add(p);
+    require.cache[p] = { id: p, filename: p, loaded: true, exports };
+  }
+  if (!seen.size) throw new Error(`stub(): could not resolve ${name}`);
+}
+
+stub('@aws-sdk/client-dynamodb', { DynamoDBClient: class {} });
+stub('@aws-sdk/lib-dynamodb', {
+  DynamoDBDocumentClient: { from: () => fakeDoc },
+  PutCommand, GetCommand, QueryCommand, UpdateCommand, DeleteCommand,
+});
+stub('@aws-sdk/client-apigatewaymanagementapi', {
+  ApiGatewayManagementApiClient: class { async send() { return {}; } },
+  PostToConnectionCommand: class { constructor(i) { this.input = i; } },
+});
+
+process.env.TABLE_NAME = 'test-table';
+process.env.WEBSOCKET_API_ENDPOINT = 'https://ws.test.invalid/dev';
+
+const { handler: createGameHandler } =
+  require(path.join(REPO, 'lambda-functions/websocket/create-game.js'));
+
+const metadataOf = (gameId) => store.get(key(`GAME#${gameId}`, 'METADATA'));
+
+async function createWith(body) {
+  store.clear();
+  const res = await createGameHandler({ body: JSON.stringify(body) });
+  const gameId = JSON.parse(res.body).gameId;
+  return metadataOf(gameId);
+}
+
+// This is the exact failure mode create-game.js documents: triviaTimer was sent
+// by the frontend for months and silently discarded because one of the three
+// edits was missed. Assert on the PERSISTED item, not the response.
+await check('omitting the flag persists anonymous ON', async () => {
+  const md = await createWith({ eventTitle: 'T', gameType: 'call-and-answer' });
+  assert.ok(md, 'no METADATA item was written at all');
+  assert.strictEqual(md.HostPreferences?.anonymousUntilReveal, true);
+});
+await check('explicit false persists as false', async () => {
+  const md = await createWith({ eventTitle: 'T', gameType: 'call-and-answer', anonymousUntilReveal: false });
+  assert.strictEqual(md.HostPreferences?.anonymousUntilReveal, false);
+});
+await check('explicit true persists as true', async () => {
+  const md = await createWith({ eventTitle: 'T', gameType: 'call-and-answer', anonymousUntilReveal: true });
+  assert.strictEqual(md.HostPreferences?.anonymousUntilReveal, true);
+});
+await check('the existing shuffle preference is not disturbed', async () => {
+  const md = await createWith({ eventTitle: 'T', gameType: 'call-and-answer', randomizeQuestions: false });
+  assert.strictEqual(md.HostPreferences?.randomizeQuestions, false);
+  assert.strictEqual(md.HostPreferences?.anonymousUntilReveal, true);
+});
+await check('the persisted flag drives the gate', async () => {
+  const md = await createWith({ eventTitle: 'T', gameType: 'call-and-answer', anonymousUntilReveal: false });
+  assert.strictEqual(isHidden(md, {}), false);
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
+
+})();

--- a/tests/anonymity-contract.js
+++ b/tests/anonymity-contract.js
@@ -214,6 +214,57 @@ await check('the persisted flag drives the gate', async () => {
   assert.strictEqual(isHidden(md, {}), false);
 });
 
+console.log('\n7. the gate binds only formats that hold a vote');
+
+const trivia = { GameType: 'trivia', HostPreferences: { anonymousUntilReveal: true } };
+const wavelength = { GameType: 'wavelength', HostPreferences: { anonymousUntilReveal: true } };
+const callAndAnswer = { GameType: 'call-and-answer', HostPreferences: { anonymousUntilReveal: true } };
+
+// Trivia's response is a letter — there is nothing authored to attribute, and
+// redacting it breaks the host's view of who answered what. Wavelength never
+// attributes on the stage. Neither format is ever offered the option, so
+// neither may be caught by a flag that defaults ON.
+await check('trivia is never hidden, even with the flag explicitly on', () =>
+  assert.strictEqual(isHidden(trivia, {}), false));
+await check('wavelength is never hidden, even with the flag explicitly on', () =>
+  assert.strictEqual(isHidden(wavelength, {}), false));
+await check('a voting format with the flag on is still hidden', () =>
+  assert.strictEqual(isHidden(callAndAnswer, {}), true));
+
+// THE CASE THIS TASK EXISTS FOR. Every game created before this feature has no
+// HostPreferences at all, so the default-ON rule caught legacy trivia and
+// wavelength games and silently redacted them.
+await check('a legacy trivia game with no HostPreferences is not hidden', () =>
+  assert.strictEqual(isHidden({ GameType: 'trivia' }, undefined), false));
+await check('a legacy call-and-answer game with no HostPreferences is hidden', () =>
+  assert.strictEqual(isHidden({ GameType: 'call-and-answer' }, undefined), true));
+await check('an absent GameType still defaults to the voting behaviour', () =>
+  assert.strictEqual(isHidden(bare, {}), true));
+
+// Legacy spellings are stored in this table. `quiz` is trivia; a row written
+// under the old spelling must not be redacted either.
+await check('the legacy spelling "quiz" is treated as trivia', () =>
+  assert.strictEqual(isHidden({ GameType: 'quiz' }, {}), false));
+
+// Drift guard, in the spirit of the byte-identical one above. anonymity.js
+// cannot require game-types.js — that module lives only in lambda-functions/game/
+// and anonymity.js must stay byte-identical across both Lambda directories — so
+// the set is inlined there. This asserts the inlined copy still agrees with the
+// canonical vocabulary for every spelling the table can hold.
+const { GAME_TYPE_IDS, ALIASES, normalizeGameType } =
+  require(path.join(REPO, 'lambda-functions/game/game-types.js'));
+
+await check('the inlined skip-set agrees with game-types.js for every spelling', () => {
+  const SKIPS_VOTE = new Set(['trivia', 'wavelength']);
+  for (const spelling of [...GAME_TYPE_IDS, ...Object.keys(ALIASES)]) {
+    const expectedHidden = !SKIPS_VOTE.has(normalizeGameType(spelling));
+    assert.strictEqual(
+      isHidden({ GameType: spelling, HostPreferences: { anonymousUntilReveal: true } }, {}),
+      expectedHidden,
+      `'${spelling}' normalises to '${normalizeGameType(spelling)}' but the gate disagreed`);
+  }
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
 

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -453,6 +453,54 @@ await check('an unpadded ANSWER# still finds the padded ROUND#001 row once revea
     `padded round lookup regression — unpadded messageType missed ROUND#001 and ` +
     `over-redacted a revealed round: ${JSON.stringify(answeredRevealedUnpadded)}`));
 
+console.log('\n11. Field Notes on an unrevealed round');
+
+// get-ai-summary.js also imports @aws-sdk/client-s3 and @aws-sdk/client-lambda,
+// which (unlike the packages stubbed above) aren't resolvable from local
+// node_modules at all — they exist only in the deployed bundle — so stub()'s
+// require.cache poisoning (which needs require.resolve to succeed first) can't
+// reach them. Hook the loader by name instead, as tests/ai-response-parsing.js
+// already does for this same file.
+const Module = require('module');
+const realLoad = Module._load;
+const noopClient = class { async send() { return {}; } };
+const extraStubs = new Map([
+  ['@aws-sdk/client-s3', { S3Client: noopClient, GetObjectCommand: class {} }],
+  ['@aws-sdk/client-lambda', { LambdaClient: noopClient, InvokeCommand: class {} }],
+]);
+Module._load = function (request, parent, isMain) {
+  if (extraStubs.has(request)) return extraStubs.get(request);
+  return realLoad.call(this, request, parent, isMain);
+};
+
+// Not hypothetical and not the model: get-ai-summary builds this string in code.
+const { buildFallbackSummary } = require(path.join(REPO, 'lambda-functions/game/get-ai-summary.js'));
+Module._load = realLoad; // restore — nothing after this point needs the hook
+
+const top = { playerName: 'Ada', answer: 'a splendid answer', score: 5, votes: 3 };
+
+await check('while hidden, the summary names nobody', () => {
+  const text = buildFallbackSummary({
+    totalParticipants: 2, votesCast: 3, top, gameType: 'call-and-answer',
+    question: 'What should we stop doing?', hidden: true
+  });
+  assert.ok(!text.includes('Ada'), `named an unrevealed author: ${text}`);
+});
+await check('while hidden, it still reports the most-supported answer', () => {
+  const text = buildFallbackSummary({
+    totalParticipants: 2, votesCast: 3, top, gameType: 'call-and-answer',
+    question: 'Q', hidden: true
+  });
+  assert.ok(/most[- ]supported|earned the most support/i.test(text), text);
+});
+await check('once revealed, it names the author as before', () => {
+  const text = buildFallbackSummary({
+    totalParticipants: 2, votesCast: 3, top, gameType: 'call-and-answer',
+    question: 'Q', hidden: false
+  });
+  assert.ok(text.includes("Ada's answer"), text);
+});
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
 

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -413,6 +413,46 @@ await check('an empty round still reveals and returns 200', () =>
 await check('an empty round returns an empty list', () =>
   assert.deepStrictEqual(JSON.parse(empty.body).answers, []));
 
+console.log('\n10. the playerAnswered round lookup pads the question number');
+
+// Review round 1 finding: message.js's ANSWER# branch built the ROUND# key
+// from the raw `messageNumber = messageType.replace('ANSWER#', '')` with no
+// .padStart(3, '0') — every other ROUND# reader/writer in this file (and in
+// start-vote.js / reveal-authors.js) pads. It fails safe today because a
+// missed lookup returns Item: undefined and isHidden(meta, undefined) still
+// evaluates to hidden — so a round seeded ANONYMOUS (the default) can't
+// distinguish a correct padded lookup from a broken unpadded one; both land on
+// "redact". To actually exercise the key-construction contract, this round is
+// seeded REVEALED: a correct padded lookup finds ROUND#001 (AuthorsRevealed:
+// true) and stops redacting; a broken unpadded lookup for 'ANSWER#1' queries
+// 'ROUND#1', misses the row entirely, falls back to the hidden default, and
+// keeps redacting — which is exactly the wrong answer once revealed, and
+// exactly what this check catches.
+seedAnonymousRound('3010', { revealed: true });
+put({ PK: 'GAME#3010', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+sent = [];
+
+await wsMessage({
+  requestContext: { connectionId: 'player-conn-3', domainName: 'ws.test.invalid', stage: 'dev' },
+  body: JSON.stringify({
+    // Unpadded on purpose — '1', not '001'. handlePlayerAnswer's own state
+    // check tolerates this (it tries both padded and unpadded forms), so this
+    // exercises only the notification's round lookup, nothing upstream of it.
+    action: 'message', gameId: '3010', playerName: 'Ada',
+    messageType: 'ANSWER#1', answer: 'a splendid answer'
+  })
+});
+
+const answeredRevealedUnpadded = sent.map(s => s.message)
+  .find(m => m.type === 'playerAnswered' || m.messageType === 'ANSWER#1');
+
+await check('an unpadded ANSWER# still finds the padded ROUND#001 row once revealed', () =>
+  assert.ok(answeredRevealedUnpadded
+    && answeredRevealedUnpadded.playerName === 'Ada'
+    && answeredRevealedUnpadded.answer === 'a splendid answer',
+    `padded round lookup regression — unpadded messageType missed ROUND#001 and ` +
+    `over-redacted a revealed round: ${JSON.stringify(answeredRevealedUnpadded)}`));
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
 

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -700,6 +700,58 @@ await check('IMPORTANT 2 fix: hidden — both participants survive the live-calc
   assert.strictEqual((liveHiddenWords.match(/a participant/g) || []).length, 2,
     `expected one redacted entry per participant, got: ${liveHiddenWords}`));
 
+console.log('\n14. voting closing reveals the round');
+
+const { handler: getResults } = require(path.join(REPO, 'lambda-functions/game/get-results.js'));
+const { isHidden } = require(path.join(REPO, 'lambda-functions/game/anonymity.js'));
+
+seedAnonymousRound('3011');
+put({ PK: 'GAME#3011', SK: 'STATE', State: 'VOTE#001', LessonNumber: 1, CurrentQuestionId: '001' });
+put({ PK: 'GAME#3011', SK: 'QUESTION#001#VOTE#Grace', PlayerName: 'Grace', Votes: { 0: 1 } });
+put({ PK: 'GAME#3011', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+sent = [];
+
+await getResults({ body: JSON.stringify({ gameId: '3011', questionNumber: 1 }) });
+
+// The promise is "until voting closes", not "until the host presses a button".
+// Closing the vote is what discharges it.
+await check('entering RESULTS sets AuthorsRevealed on the round', () =>
+  assert.strictEqual(store.get(key('GAME#3011', 'ROUND#001')).AuthorsRevealed, true));
+await check('the round is no longer hidden once results are in', () =>
+  assert.strictEqual(
+    isHidden(store.get(key('GAME#3011', 'METADATA')), store.get(key('GAME#3011', 'ROUND#001'))),
+    false));
+
+// And the ordinary answers endpoint carries names again, with no host action.
+//
+// role='host' here, deliberately, not 'player': section 1 above pins the
+// pre-existing, anonymity-unrelated invariant that the player branch only
+// ever returns a full `answers` array during VOTE# ("VOTE is the one phase
+// where BOTH roles actually receive an answers array"); everywhere else,
+// including RESULTS#, players get a count-only response regardless of
+// attribution. That gate predates this feature and is out of this task's
+// scope. role is client-supplied and carries no privilege distinction
+// (get-answers.js:11), so role='host' still proves what this check is
+// for — the endpoint carries names again with no POST /reveal-authors call.
+const afterVoteClose = JSON.parse((await askAnswers('3011', 'host')).body);
+await check('GET /answers carries attribution once voting has closed', () =>
+  assert.strictEqual(afterVoteClose.answers[0].playerName, 'Ada'));
+
+console.log('\n15. the round record is written even on the exits that used to skip it');
+
+// enterResultsState's own comment records that the state write used to be
+// missing from the wavelength and zero-vote exits. The reveal must not inherit
+// that hole: a round with no votes still closes.
+seedAnonymousRound('3013');
+put({ PK: 'GAME#3013', SK: 'STATE', State: 'VOTE#001', LessonNumber: 1, CurrentQuestionId: '001' });
+put({ PK: 'GAME#3013', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+sent = [];
+
+await getResults({ body: JSON.stringify({ gameId: '3013', questionNumber: 1 }) });
+
+await check('a round that closed with zero votes is still revealed', () =>
+  assert.strictEqual(store.get(key('GAME#3013', 'ROUND#001'))?.AuthorsRevealed, true));
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
 

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -1,0 +1,215 @@
+/**
+ * GET /games/{id}/answers must not hand out authorship while a round is
+ * anonymous — to EITHER role. `role` is a client-supplied query parameter
+ * (get-answers.js:11), not derived from auth, so "hide it from players but
+ * show it to the host" is not a guarantee this API can keep: anybody can ask
+ * for role=host. The only implementable contract is that the server does not
+ * send the names at all while hidden, regardless of what role was requested.
+ *
+ * Runs the REAL get-answers handler against a stubbed DynamoDB. Sibling of
+ * tests/anonymity-contract.js (which tests the redaction gate in isolation)
+ * and tests/vote-state-broadcast.js (which this file's stub preamble is
+ * copied from).
+ */
+const path = require('path');
+const assert = require('assert');
+
+const REPO = path.join(__dirname, '..');
+
+// ---- Stubs, installed before the handler loads -----------------------------
+class PutCommand { constructor(i) { this.input = i; this.type = 'put'; } }
+class GetCommand { constructor(i) { this.input = i; this.type = 'get'; } }
+class QueryCommand { constructor(i) { this.input = i; this.type = 'query'; } }
+class DeleteCommand { constructor(i) { this.input = i; this.type = 'delete'; } }
+class UpdateCommand { constructor(i) { this.input = i; this.type = 'update'; } }
+class PostToConnectionCommand { constructor(i) { this.input = i; } }
+
+const store = new Map();                 // "PK|SK" -> item
+const key = (pk, sk) => `${pk}|${sk}`;
+
+/** Frames the handler tried to push, in order. */
+let sent = [];
+/** Connection ids the stub should reject with 410 Gone. */
+let goneConnections = new Set();
+
+/**
+ * A minimal, honest UpdateCommand applier — the real client mutates the stored
+ * item. A stub returning {} would let a handler that never writes the state
+ * pass, which is the whole family of bug this file guards.
+ */
+function applyUpdate(input) {
+  const k = key(input.Key.PK, input.Key.SK);
+  const item = store.get(k) || { ...input.Key };
+  const names = input.ExpressionAttributeNames || {};
+  const values = input.ExpressionAttributeValues || {};
+
+  const setClause = String(input.UpdateExpression || '').replace(/^\s*SET\s+/i, '');
+  for (const pair of setClause.split(',')) {
+    const [lhs, rhs] = pair.split('=').map((s) => s.trim());
+    if (!lhs || !rhs) continue;
+    const attr = names[lhs] || lhs;
+    item[attr] = values[rhs];
+  }
+  store.set(k, item);
+  return {};
+}
+
+const fakeDoc = {
+  send: async (cmd) => {
+    const inp = cmd.input || {};
+    switch (cmd.type) {
+      case 'put':
+        store.set(key(inp.Item.PK, inp.Item.SK), inp.Item);
+        return {};
+      case 'get':
+        return { Item: store.get(key(inp.Key.PK, inp.Key.SK)) };
+      case 'delete':
+        store.delete(key(inp.Key.PK, inp.Key.SK));
+        return {};
+      case 'update':
+        return applyUpdate(inp);
+      case 'query': {
+        const pk = inp.ExpressionAttributeValues[':pk'];
+        const prefix = inp.ExpressionAttributeValues[':sk'] ?? '';
+        const items = [...store.values()].filter(
+          (i) => i.PK === pk && String(i.SK).startsWith(String(prefix))
+        );
+        return { Items: items, Count: items.length };
+      }
+      default:
+        return {};
+    }
+  },
+};
+
+class FakeApiGatewayClient {
+  async send(cmd) {
+    const { ConnectionId, Data } = cmd.input;
+    if (goneConnections.has(ConnectionId)) {
+      const err = new Error('Gone');
+      err.name = 'GoneException';
+      err.statusCode = 410;
+      throw err;
+    }
+    sent.push({ connectionId: ConnectionId, message: JSON.parse(Data) });
+    return {};
+  }
+}
+
+// Handlers live in lambda-functions/<group>/, each of which may carry its own
+// node_modules. Node resolves from the requiring file upward, so poison every
+// resolvable copy or the real SDK loads and the test dies on credentials.
+const STUB_PATHS = [
+  REPO,
+  path.join(REPO, 'lambda-functions'),
+  path.join(REPO, 'lambda-functions', 'game'),
+  path.join(REPO, 'lambda-functions', 'websocket'),
+];
+
+function stub(name, exports) {
+  const seen = new Set();
+  for (const base of STUB_PATHS) {
+    let p;
+    try { p = require.resolve(name, { paths: [base] }); } catch { continue; }
+    if (seen.has(p)) continue;
+    seen.add(p);
+    require.cache[p] = { id: p, filename: p, loaded: true, exports };
+  }
+  if (!seen.size) throw new Error(`stub(): could not resolve ${name}`);
+}
+
+stub('@aws-sdk/client-dynamodb', { DynamoDBClient: class {} });
+stub('@aws-sdk/lib-dynamodb', {
+  DynamoDBDocumentClient: { from: () => fakeDoc },
+  PutCommand, GetCommand, QueryCommand, DeleteCommand, UpdateCommand,
+});
+stub('@aws-sdk/client-apigatewaymanagementapi', {
+  ApiGatewayManagementApiClient: FakeApiGatewayClient,
+  PostToConnectionCommand,
+});
+
+process.env.TABLE_NAME = 'test-table';
+process.env.WEBSOCKET_API_ENDPOINT = 'https://ws.test.invalid/dev';
+
+const { handler: getAnswers } = require(path.join(REPO, 'lambda-functions/game/get-answers.js'));
+
+// ---- Tiny harness ----------------------------------------------------------
+let pass = 0, fail = 0;
+async function check(label, fn) {
+  try { await fn(); console.log(`  PASS  ${label}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${label}\n        ${e.message}`); fail++; }
+}
+
+const put = (item) => store.set(key(item.PK, item.SK), item);
+
+/** A call-and-answer game mid-ASK with two answers in. */
+function seedAnonymousRound(gameId, { anonymous = true, revealed = false } = {}) {
+  store.clear();
+  sent = [];
+  put({ PK: `GAME#${gameId}`, SK: 'METADATA', GameType: 'call-and-answer', Title: 'T',
+        HostPreferences: { randomizeQuestions: true, anonymousUntilReveal: anonymous } });
+  put({ PK: `GAME#${gameId}`, SK: 'STATE', State: 'ASK#001', LessonNumber: 1, CurrentQuestionId: '001' });
+  put({ PK: `GAME#${gameId}`, SK: 'ROUND#001', QuestionNumber: '001', AuthorsRevealed: revealed });
+  for (const n of ['Ada', 'Grace']) {
+    put({ PK: `GAME#${gameId}`, SK: `QUESTION#001#ANSWER#${n}`,
+          PlayerName: n, Answer: `${n}'s answer`, SubmittedAt: '2026-01-01T00:00:00.000Z' });
+  }
+}
+
+const askAnswers = (gameId, role) => getAnswers({
+  pathParameters: { gameId },
+  queryStringParameters: { role, questionId: '001' }
+});
+
+(async () => {
+
+console.log('\n1. GET /answers while hidden');
+
+seedAnonymousRound('3001');
+const asHost = JSON.parse((await askAnswers('3001', 'host')).body);
+const asPlayer = JSON.parse((await askAnswers('3001', 'player')).body);
+
+await check('the host payload carries no playerName', () =>
+  assert.ok(asHost.answers.every(a => !('playerName' in a)),
+    `leaked: ${JSON.stringify(asHost.answers[0])}`));
+await check('the host payload carries no name', () =>
+  assert.ok(asHost.answers.every(a => !('name' in a))));
+// role is client-supplied, so "host" is not a trust boundary. Both branches
+// must redact identically or the feature is a label on a leak.
+await check('role=host and role=player return identical attribution', () =>
+  assert.deepStrictEqual(
+    asHost.answers.map(a => Object.keys(a).sort()),
+    asPlayer.answers.map(a => Object.keys(a).sort())));
+await check('the answers themselves survive, in order', () =>
+  assert.deepStrictEqual(asHost.answers.map(a => a.answer),
+    ["Ada's answer", "Grace's answer"]));
+await check('the count is unchanged', () =>
+  assert.strictEqual(asHost.answerCount, 2));
+
+console.log('\n2. GET /answers once revealed');
+
+seedAnonymousRound('3002', { revealed: true });
+const revealed = JSON.parse((await askAnswers('3002', 'host')).body);
+await check('revealed rounds carry playerName again', () =>
+  assert.strictEqual(revealed.answers[0].playerName, 'Ada'));
+
+console.log('\n3. GET /answers with anonymity turned off');
+
+seedAnonymousRound('3003', { anonymous: false });
+const plain = JSON.parse((await askAnswers('3003', 'host')).body);
+await check('opting out carries playerName from the start', () =>
+  assert.strictEqual(plain.answers[0].playerName, 'Ada'));
+
+console.log('\n4. a game with no HostPreferences at all');
+
+seedAnonymousRound('3004');
+delete store.get(key('GAME#3004', 'METADATA')).HostPreferences;
+const legacy = JSON.parse((await askAnswers('3004', 'host')).body);
+// Games created before this feature must be anonymous, not accidentally open.
+await check('a pre-feature game defaults to hidden', () =>
+  assert.ok(!('playerName' in legacy.answers[0])));
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);
+
+})();

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -22,6 +22,7 @@ class GetCommand { constructor(i) { this.input = i; this.type = 'get'; } }
 class QueryCommand { constructor(i) { this.input = i; this.type = 'query'; } }
 class DeleteCommand { constructor(i) { this.input = i; this.type = 'delete'; } }
 class UpdateCommand { constructor(i) { this.input = i; this.type = 'update'; } }
+class ScanCommand { constructor(i) { this.input = i; this.type = 'scan'; } }
 class PostToConnectionCommand { constructor(i) { this.input = i; } }
 
 const store = new Map();                 // "PK|SK" -> item
@@ -76,6 +77,19 @@ const fakeDoc = {
         );
         return { Items: items, Count: items.length };
       }
+      case 'scan': {
+        // Only real caller is get-ai-summary.js's findDefaultPromptId, which
+        // always scans for `PK = :pk AND isDefault = :isDefault`. A generic
+        // AND-of-equalities filter over ExpressionAttributeValues is enough
+        // for that shape without pretending to be a real Scan.
+        const values = inp.ExpressionAttributeValues || {};
+        const items = [...store.values()].filter((i) => {
+          if (values[':pk'] !== undefined && i.PK !== values[':pk']) return false;
+          if (values[':isDefault'] !== undefined && i.isDefault !== values[':isDefault']) return false;
+          return true;
+        });
+        return { Items: items, Count: items.length };
+      }
       default:
         return {};
     }
@@ -121,7 +135,7 @@ function stub(name, exports) {
 stub('@aws-sdk/client-dynamodb', { DynamoDBClient: class {} });
 stub('@aws-sdk/lib-dynamodb', {
   DynamoDBDocumentClient: { from: () => fakeDoc },
-  PutCommand, GetCommand, QueryCommand, DeleteCommand, UpdateCommand,
+  PutCommand, GetCommand, QueryCommand, DeleteCommand, UpdateCommand, ScanCommand,
 });
 stub('@aws-sdk/client-apigatewaymanagementapi', {
   ApiGatewayManagementApiClient: FakeApiGatewayClient,
@@ -461,12 +475,26 @@ console.log('\n11. Field Notes on an unrevealed round');
 // require.cache poisoning (which needs require.resolve to succeed first) can't
 // reach them. Hook the loader by name instead, as tests/ai-response-parsing.js
 // already does for this same file.
+//
+// @aws-sdk/client-bedrock-runtime IS resolvable locally (unlike the two
+// above), so it would otherwise load for real and try an actual network call
+// to AWS the moment any test below drives generateAISummary() past prompt
+// resolution. Stub it to fail fast and deterministically instead — every
+// test below that reaches Bedrock is exercising the fallback-on-failure path
+// (buildFallback(), with debugInfo still attached under debugMode), which is
+// realistic: Bedrock failing is exactly the everyday case this fallback
+// exists for, and it's the same code path a real throttle or outage takes.
+// The client is a MODULE-LEVEL singleton in get-ai-summary.js (created once,
+// at require time) — this stub has to be in place before the FIRST require
+// of that file below, or a later section stubbing it would be too late.
 const Module = require('module');
 const realLoad = Module._load;
 const noopClient = class { async send() { return {}; } };
+const throwingBedrock = class { async send() { throw new Error('stub: no Bedrock in tests'); } };
 const extraStubs = new Map([
   ['@aws-sdk/client-s3', { S3Client: noopClient, GetObjectCommand: class {} }],
   ['@aws-sdk/client-lambda', { LambdaClient: noopClient, InvokeCommand: class {} }],
+  ['@aws-sdk/client-bedrock-runtime', { BedrockRuntimeClient: throwingBedrock, InvokeModelCommand: class {} }],
 ]);
 Module._load = function (request, parent, isMain) {
   if (extraStubs.has(request)) return extraStubs.get(request);
@@ -474,7 +502,11 @@ Module._load = function (request, parent, isMain) {
 };
 
 // Not hypothetical and not the model: get-ai-summary builds this string in code.
-const { buildFallbackSummary } = require(path.join(REPO, 'lambda-functions/game/get-ai-summary.js'));
+const {
+  buildFallbackSummary,
+  generateAISummary,
+  handler: getAiSummary,
+} = require(path.join(REPO, 'lambda-functions/game/get-ai-summary.js'));
 Module._load = realLoad; // restore — nothing after this point needs the hook
 
 const top = { playerName: 'Ada', answer: 'a splendid answer', score: 5, votes: 3 };
@@ -500,6 +532,173 @@ await check('once revealed, it names the author as before', () => {
   });
   assert.ok(text.includes("Ada's answer"), text);
 });
+
+console.log('\n12. GET AI summary — the model prompt itself is redacted, not just the fallback template');
+
+// Review round 2, IMPORTANT 3: section 11 only unit-tests buildFallbackSummary
+// with hand-built arguments — nothing drove the real isHidden(metadata,
+// roundRecord.Item) wiring added to exports.handler, nor the hidden-gated
+// answers/results.voteTallies/results.winners redaction at the top of
+// generateAISummary, nor whether the redacted values actually reach the
+// assembled Bedrock prompt (and, via debug=true, get-ai-summary.js's own
+// cache-hit/promptDebug branches — the leak this task exists to close). This
+// section drives the REAL exports.handler end to end.
+//
+// A minimal usable prompt template, seeded once and re-seeded per call since
+// seedAnonymousRound() clears the whole store. s3Key present + the stubbed S3
+// client resolving to a bodyless {} makes fetchPromptFromS3 fall through to
+// its OWN "use the DynamoDB record" final fallback (get-ai-summary.js, inside
+// fetchPromptFromS3's catch block) — the simplest way to hand this a usable
+// .template without a real S3 object.
+const AI_PROMPT_TEMPLATE =
+  'Q: {questionTitle}\n' +
+  'RESPONSES: {responsesText}\n' +
+  'WINNER: {winnerInfo}\n' +
+  'TOP: {topVotedAnswers}\n' +
+  'PLAYERS: {playerNames}\n' +
+  'ROUND SCORES: {roundScores}\n' +
+  'SCORE CHANGES: {scoreChanges}\n' +
+  'PLAYER ANSWERS: {playerAnswers}\n' +
+  '=== SUMMARY ===\nx\n=== DISCUSSION QUESTIONS ===\nQ1: x\n=== NEXT STEPS ===\nSTEP1: x';
+
+async function runAiSummaryWorker(gameId, { revealed }) {
+  seedAnonymousRound(gameId, { revealed });
+  put({ PK: 'AIPROMPTS', SK: 'AIPROMPT#lessons-learned', s3Key: 'fake-key', template: AI_PROMPT_TEMPLATE });
+  // seedAnonymousRound's default answer TEXT is "Ada's answer" / "Grace's
+  // answer" — the player's name is literally embedded in the CONTENT, which
+  // is legitimately never redacted (only authorship is). A blanket "does not
+  // include 'Ada'" check on the assembled prompt would otherwise trip on that
+  // correctly-preserved answer text, not on a real name leak. Overwrite the
+  // content here (own put(), not a change to the shared helper) so the checks
+  // below can only be about the playerName field.
+  put({ PK: `GAME#${gameId}`, SK: 'QUESTION#001#ANSWER#Ada', PlayerName: 'Ada', Answer: 'loves the ocean', SubmittedAt: '2026-01-01T00:00:00.000Z' });
+  put({ PK: `GAME#${gameId}`, SK: 'QUESTION#001#ANSWER#Grace', PlayerName: 'Grace', Answer: 'prefers the mountains', SubmittedAt: '2026-01-01T00:00:00.000Z' });
+  // A vote from a THIRD person (not an answer author) gives voteTallies/winners
+  // real, non-zero content to redact — the ocean answer (index 0, seeded
+  // first) gets the first-place vote.
+  put({ PK: `GAME#${gameId}`, SK: 'QUESTION#001#VOTE#Mallory', PlayerName: 'Mallory', Votes: { '0': 1 } });
+  put({ PK: `GAME#${gameId}`, SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+
+  const res = await getAiSummary({ __workerMode: true, gameId, questionId: '001', debug: 'true' });
+  const stored = store.get(key(`GAME#${gameId}`, 'QUESTION#001#AISummary'));
+  return { res, stored };
+}
+
+const hidden12 = await runAiSummaryWorker('3011', { revealed: false });
+
+await check('worker mode completes and returns ok', () =>
+  assert.strictEqual(hidden12.res.ok, true, JSON.stringify(hidden12.res)));
+await check('an AISummary record was persisted with DebugInfo attached', () =>
+  assert.ok(hidden12.stored && hidden12.stored.DebugInfo, 'debug=true should have attached DebugInfo'));
+
+const hiddenPrompt = hidden12.stored.DebugInfo.fullPrompt;
+const hiddenVars = JSON.stringify(hidden12.stored.DebugInfo.templateVariables);
+
+await check('hidden: no answer author name reaches the assembled prompt sent to the model', () =>
+  assert.ok(!hiddenPrompt.includes('Ada') && !hiddenPrompt.includes('Grace'),
+    `leaked into fullPrompt: ${hiddenPrompt}`));
+await check('hidden: no answer author name reaches any template variable (incl. ones debug=true returns raw)', () =>
+  assert.ok(!hiddenVars.includes('Ada') && !hiddenVars.includes('Grace'),
+    `leaked into templateVariables: ${hiddenVars}`));
+await check('hidden: the placeholder is what was actually substituted, not an empty/undefined field', () =>
+  assert.ok(hiddenPrompt.includes('a participant'),
+    `expected the redaction placeholder somewhere in the prompt: ${hiddenPrompt}`));
+await check('hidden: the persisted fallback summary text also names nobody (end-to-end, not just in isolation)', () =>
+  assert.ok(!hidden12.stored.SummaryText.includes('Ada'), hidden12.stored.SummaryText));
+
+// IMPORTANT 4: discussionQuestions must not quote the answer verbatim while
+// hidden either — same closure (buildFallback()), same markdownResponse.
+await check('IMPORTANT 4 fix: hidden discussion questions do not quote the answer verbatim', () =>
+  assert.ok(!hidden12.stored.DiscussionQuestions.some((q) => q.includes('"')),
+    `still quoting the answer while hidden: ${JSON.stringify(hidden12.stored.DiscussionQuestions)}`));
+await check('hidden discussion questions use the same unattributed phrasing as the fallback summary', () =>
+  assert.ok(hidden12.stored.DiscussionQuestions.some((q) => /most-supported response/i.test(q)),
+    JSON.stringify(hidden12.stored.DiscussionQuestions)));
+
+// Revealed counterpart — proves the checks above are not vacuous (e.g. a
+// broken template that never substitutes anything would also show "no Ada").
+const revealed12 = await runAiSummaryWorker('3012', { revealed: true });
+const revealedVars = JSON.stringify(revealed12.stored.DebugInfo.templateVariables);
+
+await check('revealed: the answer author DOES appear in the template variables (proves the playerName checks above are not vacuous)', () =>
+  assert.ok(revealedVars.includes('Ada'), revealedVars));
+await check('revealed: discussion questions quote the answer verbatim again, as before this task', () =>
+  assert.ok(revealed12.stored.DiscussionQuestions.some((q) => q.includes('"loves the ocean"')),
+    JSON.stringify(revealed12.stored.DiscussionQuestions)));
+
+console.log('\n13. Wavelength: both the stored-results cache path and the live-calculation path redact without dropping participants');
+
+// CRITICAL 1 + IMPORTANT 2: generateAISummary is called directly here
+// (exported above), not through exports.handler. Reaching the wavelength
+// branch through the real handler currently throws on an unrelated,
+// pre-existing bug — exports.handler's OWN wavelength vote-tally pass
+// (get-ai-summary.js, the `else if (gameType === 'wavelength')` block inside
+// the vote-processing section) references a bare `commonWords`, which is
+// never declared anywhere in that function's scope; it is only ever declared
+// inside generateAISummary, a completely separate function with no closure
+// over it. That bug predates this task, is not one of the four review
+// findings, and touches wavelength summary generation generally rather than
+// anonymity — left alone here (see the fix report). Calling generateAISummary
+// directly is the only way to give the wavelength redaction fixed in this
+// task real coverage without also fixing that unrelated crash.
+put({
+  PK: 'AIPROMPTS', SK: 'AIPROMPT#lessons-learned', s3Key: 'fake-key',
+  template: 'WORDS: {wavelengthWords}\n=== SUMMARY ===\nx\n=== DISCUSSION QUESTIONS ===\nQ1: x\n=== NEXT STEPS ===\nSTEP1: x',
+});
+
+const wavelengthAnswers = [
+  { playerName: 'Ada', answer: 'ocean,blue' },
+  { playerName: 'Grace', answer: 'ocean,tide' },
+];
+const wavelengthBaseArgs = {
+  eventTitle: 'Wavelength Test', gameType: 'wavelength', gameAiContext: '', questionSetAiContext: '',
+  customInstruction: '', promptId: 'lessons-learned', promptProvenance: { hierarchy: [] }, debugMode: true,
+  questionId: '001', question: { title: 'Pick a word' },
+  results: { voteTallies: {}, winners: [], totalVotes: 0 },
+  votes: [], gameId: 'wave-1', questionSetId: null, paddedQuestionNumber: '001',
+  scoringConfig: { firstPlacePoints: 3, secondPlacePoints: 2, thirdPlacePoints: 1 },
+  hostPersonaId: null, setPersonaId: null,
+};
+
+// 13a. Stored-results cache path (CRITICAL 1's exact location).
+const storedResultsFixture = {
+  wordAnalysis: { commonWords: [{ word: 'ocean', count: 2 }], wordCounts: { ocean: 2 }, totalUniqueWords: 3, connectionScore: 67 },
+  playerAnswers: wavelengthAnswers,
+};
+
+const storedHidden = await generateAISummary({
+  ...wavelengthBaseArgs, hidden: true, answers: wavelengthAnswers, storedResults: storedResultsFixture,
+});
+const storedHiddenWords = storedHidden.debugInfo.templateVariables.wavelengthWords;
+
+await check('CRITICAL 1 fix: hidden — storedResults.playerAnswers no longer leaks names into wavelengthWords', () =>
+  assert.ok(!storedHiddenWords.includes('Ada') && !storedHiddenWords.includes('Grace'),
+    `leaked via the stored-results cache path: ${storedHiddenWords}`));
+await check('IMPORTANT 2 fix: hidden — both participants survive the stored-results path, not just the last', () =>
+  assert.strictEqual((storedHiddenWords.match(/a participant/g) || []).length, 2,
+    `expected one redacted entry per participant, got: ${storedHiddenWords}`));
+
+const storedRevealed = await generateAISummary({
+  ...wavelengthBaseArgs, hidden: false, answers: wavelengthAnswers, storedResults: storedResultsFixture,
+});
+const storedRevealedWords = storedRevealed.debugInfo.templateVariables.wavelengthWords;
+await check('revealed — both real names appear (proves the two hidden checks above are not vacuous)', () =>
+  assert.ok(storedRevealedWords.includes('Ada') && storedRevealedWords.includes('Grace'), storedRevealedWords));
+
+// 13b. Live-calculation path — no stored-results cache hit (IMPORTANT 2's
+// other half: `answers` was already redacted at the top of generateAISummary,
+// so no name leaks even without this fix, but the naive object-keyed-by-name
+// collision still dropped every participant but the last).
+const liveHidden = await generateAISummary({
+  ...wavelengthBaseArgs, hidden: true, answers: wavelengthAnswers, storedResults: null,
+});
+const liveHiddenWords = liveHidden.debugInfo.templateVariables.wavelengthWords;
+
+await check('hidden — the live-calculation path (no stored results) does not leak names', () =>
+  assert.ok(!liveHiddenWords.includes('Ada') && !liveHiddenWords.includes('Grace'), liveHiddenWords));
+await check('IMPORTANT 2 fix: hidden — both participants survive the live-calculation path too', () =>
+  assert.strictEqual((liveHiddenWords.match(/a participant/g) || []).length, 2,
+    `expected one redacted entry per participant, got: ${liveHiddenWords}`));
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -270,6 +270,81 @@ await check('votingStarted carries no attribution and never did', () => {
     'the broadcast has grown an attribution field');
 });
 
+console.log('\n6. the playerAnswered socket frame');
+
+// This is the leak a purely HTTP redaction would leave behind: the host's
+// socket receives a live author-to-answer mapping in real time, before any
+// endpoint is called.
+const { handler: wsMessage } = require(path.join(REPO, 'lambda-functions/websocket/message.js'));
+
+seedAnonymousRound('3006');
+put({ PK: 'GAME#3006', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+sent = [];
+
+// NOTE ON EVENT SHAPE: handlePlayerMessage(gameId, playerName, messageType,
+// messageData) is called with the ENTIRE parsed body as `messageData` (see
+// message.js's handler: `handlePlayerMessage(gameId, playerName, messageType,
+// body)`), and handlePlayerAnswer destructures `const { answer } =
+// messageData` off that same object. So the answer text belongs at the top
+// level of the body, not nested under a `messageData: {...}` envelope — a
+// nested shape would leave `answer` inaccessible to the handler and would
+// make the leak this test exists to catch invisible by accident rather than
+// by the redaction actually working.
+await wsMessage({
+  requestContext: { connectionId: 'player-conn-1', domainName: 'ws.test.invalid', stage: 'dev' },
+  body: JSON.stringify({
+    action: 'message', gameId: '3006', playerName: 'Ada',
+    messageType: 'ANSWER#001', answer: 'a splendid answer'
+  })
+});
+
+const answered = sent.map(s => s.message).find(m => m.type === 'playerAnswered' || m.messageType === 'ANSWER#001');
+
+// NOTE: `check` is async, so it must be awaited — a bare `check(...)` here
+// races the final summary/process.exit() and can silently drop the LAST
+// unawaited check's result before its microtask ever runs (caught empirically:
+// with these calls unawaited, the file reported 20 checks even though 21
+// check() calls exist in source). Every other section in this file already
+// awaits; matching that here.
+await check('a playerAnswered frame was still sent', () =>
+  assert.ok(answered, 'the host was told nothing at all — progress would stall'));
+await check('the frame names nobody', () =>
+  assert.ok(!('playerName' in answered),
+    `leaked author over the socket: ${JSON.stringify(answered)}`));
+await check('the frame carries no answer text', () =>
+  assert.ok(!('answer' in answered),
+    `leaked answer body over the socket: ${JSON.stringify(answered)}`));
+await check('the frame still identifies the round', () =>
+  assert.strictEqual(String(answered.questionNumber), '001'));
+
+console.log('\n7. playerVoted is NOT anonymised');
+
+seedAnonymousRound('3007');
+put({ PK: 'GAME#3007', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+sent = [];
+await wsMessage({
+  requestContext: { connectionId: 'player-conn-2', domainName: 'ws.test.invalid', stage: 'dev' },
+  body: JSON.stringify({
+    action: 'message', gameId: '3007', playerName: 'Ada',
+    messageType: 'VOTE#001', votedFor: 'Grace'
+  })
+});
+// NOTE ON EVENT SHAPE: message.js's isHostMessage() matches ANY
+// 'VOTE#'-prefixed messageType, and the top-level handler checks
+// isHostMessage() before isPlayerMessage() — so a player-originated
+// VOTE#001 message is always routed through handleHostMessage, never through
+// handlePlayerMessage's own VOTE# branch (the one that assigns
+// notificationType = 'playerVoted', and the one this task's binding
+// constraints forbid touching). That branch is unreachable through the real
+// exported handler for any messageType value; it's a pre-existing routing
+// property, not something this task's redaction change affects. §5.6.6: this
+// feature is about who WROTE an answer, not who voted for it — the invariant
+// this test can honestly check against the real handler is that whatever
+// frame VOTE#001 does produce keeps the player's name.
+const voted = sent.map(s => s.message).find(m => m.messageType === 'VOTE#001');
+await check('playerVoted keeps its playerName', () =>
+  assert.strictEqual(voted?.playerName, 'Ada'));
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
 

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -345,6 +345,74 @@ const voted = sent.map(s => s.message).find(m => m.messageType === 'VOTE#001');
 await check('playerVoted keeps its playerName', () =>
   assert.strictEqual(voted?.playerName, 'Ada'));
 
+console.log('\n8. POST /reveal-authors');
+
+const { handler: revealAuthors } = require(path.join(REPO, 'lambda-functions/game/reveal-authors.js'));
+
+seedAnonymousRound('3008');
+put({ PK: 'GAME#3008', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+put({ PK: 'GAME#3008', SK: 'CONNECTION#player-1', ConnectionId: 'player-1', ConnectionType: 'PLAYER' });
+sent = [];
+
+const rev = await revealAuthors({
+  pathParameters: { gameId: '3008' },
+  body: JSON.stringify({ questionNumber: 1 })
+});
+const revBody = JSON.parse(rev.body);
+
+await check('responds 200', () =>
+  assert.strictEqual(rev.statusCode, 200, rev.body));
+await check('persists AuthorsRevealed on the round', () =>
+  assert.strictEqual(store.get(key('GAME#3008', 'ROUND#001')).AuthorsRevealed, true));
+await check('returns the rows with attribution joined back on', () =>
+  assert.deepStrictEqual(revBody.answers.map(a => a.playerName), ['Ada', 'Grace']));
+await check('order is still the ballot order', () =>
+  assert.deepStrictEqual(revBody.answers.map(a => a.answer),
+    ["Ada's answer", "Grace's answer"]));
+await check('announces to every connection, host included', () =>
+  assert.deepStrictEqual(sent.map(s => s.connectionId).sort(), ['host-1', 'player-1']));
+await check('the frame is an authorsRevealed carrying the round', () => {
+  const f = sent[0].message;
+  assert.strictEqual(f.type, 'authorsRevealed');
+  assert.strictEqual(f.gameId, '3008');
+  assert.strictEqual(String(f.questionNumber), '001');
+});
+
+// A host double-tapping in front of a room must not error.
+sent = [];
+const again = await revealAuthors({
+  pathParameters: { gameId: '3008' }, body: JSON.stringify({ questionNumber: 1 })
+});
+await check('is idempotent — a second reveal still returns 200', () =>
+  assert.strictEqual(again.statusCode, 200));
+await check('is idempotent — still revealed', () =>
+  assert.strictEqual(store.get(key('GAME#3008', 'ROUND#001')).AuthorsRevealed, true));
+
+// After reveal, the ordinary answers endpoint carries names again.
+// NOTE ON EVENT SHAPE: the brief's draft asked role=player here, but this
+// round is seeded (by seedAnonymousRound's default) at ASK#001, and
+// get-answers.js's player branch only returns an `answers` array at all
+// during VOTE# (see section 1's "during ASK, the player branch returns no
+// answers array at all" — a pre-existing, anonymity-unrelated gate). role=host
+// is the branch that actually carries answers during ASK, matching section 3's
+// use of 'host' to check the same post-reveal property. Fixing the test, not
+// the handler, per the task brief.
+const afterReveal = JSON.parse((await askAnswers('3008', 'host')).body);
+await check('GET /answers now carries attribution', () =>
+  assert.strictEqual(afterReveal.answers[0].playerName, 'Ada'));
+
+console.log('\n9. reveal on a round with no answers');
+
+seedAnonymousRound('3009');
+for (const n of ['Ada', 'Grace']) store.delete(key('GAME#3009', `QUESTION#001#ANSWER#${n}`));
+const empty = await revealAuthors({
+  pathParameters: { gameId: '3009' }, body: JSON.stringify({ questionNumber: 1 })
+});
+await check('an empty round still reveals and returns 200', () =>
+  assert.strictEqual(empty.statusCode, 200));
+await check('an empty round returns an empty list', () =>
+  assert.deepStrictEqual(JSON.parse(empty.body).answers, []));
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
 

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -142,13 +142,17 @@ async function check(label, fn) {
 
 const put = (item) => store.set(key(item.PK, item.SK), item);
 
-/** A call-and-answer game mid-ASK with two answers in. */
-function seedAnonymousRound(gameId, { anonymous = true, revealed = false } = {}) {
+/**
+ * A call-and-answer game mid-round with two answers in. Defaults to ASK#001;
+ * pass `state: 'VOTE#001'` for checks that need the player branch to actually
+ * return an answers array (see section 2 below).
+ */
+function seedAnonymousRound(gameId, { anonymous = true, revealed = false, state = 'ASK#001' } = {}) {
   store.clear();
   sent = [];
   put({ PK: `GAME#${gameId}`, SK: 'METADATA', GameType: 'call-and-answer', Title: 'T',
         HostPreferences: { randomizeQuestions: true, anonymousUntilReveal: anonymous } });
-  put({ PK: `GAME#${gameId}`, SK: 'STATE', State: 'ASK#001', LessonNumber: 1, CurrentQuestionId: '001' });
+  put({ PK: `GAME#${gameId}`, SK: 'STATE', State: state, LessonNumber: 1, CurrentQuestionId: '001' });
   put({ PK: `GAME#${gameId}`, SK: 'ROUND#001', QuestionNumber: '001', AuthorsRevealed: revealed });
   for (const n of ['Ada', 'Grace']) {
     put({ PK: `GAME#${gameId}`, SK: `QUESTION#001#ANSWER#${n}`,
@@ -163,44 +167,68 @@ const askAnswers = (gameId, role) => getAnswers({
 
 (async () => {
 
-console.log('\n1. GET /answers while hidden');
+console.log('\n1. GET /answers while hidden (ASK phase)');
 
 seedAnonymousRound('3001');
 const asHost = JSON.parse((await askAnswers('3001', 'host')).body);
-const asPlayer = JSON.parse((await askAnswers('3001', 'player')).body);
+const asPlayerAsk = JSON.parse((await askAnswers('3001', 'player')).body);
 
 await check('the host payload carries no playerName', () =>
   assert.ok(asHost.answers.every(a => !('playerName' in a)),
     `leaked: ${JSON.stringify(asHost.answers[0])}`));
 await check('the host payload carries no name', () =>
   assert.ok(asHost.answers.every(a => !('name' in a))));
-// role is client-supplied, so "host" is not a trust boundary. Both branches
-// must redact identically or the feature is a label on a leak.
-await check('role=host and role=player return identical attribution', () =>
-  assert.deepStrictEqual(
-    asHost.answers.map(a => Object.keys(a).sort()),
-    asPlayer.answers.map(a => Object.keys(a).sort())));
 await check('the answers themselves survive, in order', () =>
   assert.deepStrictEqual(asHost.answers.map(a => a.answer),
     ["Ada's answer", "Grace's answer"]));
 await check('the count is unchanged', () =>
   assert.strictEqual(asHost.answerCount, 2));
+// During ASK, players don't get anyone's answers yet — count only. That's an
+// older, pre-vote gate, unrelated to anonymity (it exists so players aren't
+// influenced before they answer, and it applies whether or not the round is
+// anonymous). Pin it here: this is exactly the property that broke an
+// earlier version of the parity check below when it was seeded at ASK
+// instead of VOTE.
+await check('during ASK, the player branch returns no answers array at all', () =>
+  assert.ok(!('answers' in asPlayerAsk),
+    `unexpected answers key during ASK: ${JSON.stringify(asPlayerAsk)}`));
 
-console.log('\n2. GET /answers once revealed');
+console.log('\n2. GET /answers while hidden (VOTE phase — parity, host vs. player)');
+
+// Seeded at VOTE#001, not ASK#001. Anonymity is only load-bearing here: VOTE
+// is the one phase where BOTH roles actually receive an answers array (see
+// the ASK invariant above), so it's the only phase where "host and player
+// are given identical attribution" is even a testable claim. Do not move
+// this seed back to ASK — that was the original bug in this file.
+seedAnonymousRound('3005', { state: 'VOTE#001' });
+const asHostVote = JSON.parse((await askAnswers('3005', 'host')).body);
+const asPlayerVote = JSON.parse((await askAnswers('3005', 'player')).body);
+
+// role is client-supplied, so "host" is not a trust boundary. Both branches
+// must redact identically or the feature is a label on a leak.
+await check('role=host and role=player return identical attribution', () =>
+  assert.deepStrictEqual(
+    asHostVote.answers.map(a => Object.keys(a).sort()),
+    asPlayerVote.answers.map(a => Object.keys(a).sort()),
+    'role is client-supplied, so any difference here means a player who asks ' +
+    'for role=host sees names a real player could not — the whole design ' +
+    'assumes both branches are given the same thing to send'));
+
+console.log('\n3. GET /answers once revealed');
 
 seedAnonymousRound('3002', { revealed: true });
 const revealed = JSON.parse((await askAnswers('3002', 'host')).body);
 await check('revealed rounds carry playerName again', () =>
   assert.strictEqual(revealed.answers[0].playerName, 'Ada'));
 
-console.log('\n3. GET /answers with anonymity turned off');
+console.log('\n4. GET /answers with anonymity turned off');
 
 seedAnonymousRound('3003', { anonymous: false });
 const plain = JSON.parse((await askAnswers('3003', 'host')).body);
 await check('opting out carries playerName from the start', () =>
   assert.strictEqual(plain.answers[0].playerName, 'Ada'));
 
-console.log('\n4. a game with no HostPreferences at all');
+console.log('\n5. a game with no HostPreferences at all');
 
 seedAnonymousRound('3004');
 delete store.get(key('GAME#3004', 'METADATA')).HostPreferences;

--- a/tests/anonymous-round-flow.js
+++ b/tests/anonymous-round-flow.js
@@ -132,6 +132,7 @@ process.env.TABLE_NAME = 'test-table';
 process.env.WEBSOCKET_API_ENDPOINT = 'https://ws.test.invalid/dev';
 
 const { handler: getAnswers } = require(path.join(REPO, 'lambda-functions/game/get-answers.js'));
+const { handler: startVote } = require(path.join(REPO, 'lambda-functions/websocket/start-vote.js'));
 
 // ---- Tiny harness ----------------------------------------------------------
 let pass = 0, fail = 0;
@@ -236,6 +237,38 @@ const legacy = JSON.parse((await askAnswers('3004', 'host')).body);
 // Games created before this feature must be anonymous, not accidentally open.
 await check('a pre-feature game defaults to hidden', () =>
   assert.ok(!('playerName' in legacy.answers[0])));
+
+console.log('\n5. POST /start-vote while hidden');
+
+seedAnonymousRound('3005');
+// seedAnonymousRound doesn't seed connections (it's built for get-answers, which
+// doesn't broadcast). start-vote's votingStarted frame only reaches `sent` if
+// broadcastToGame finds at least one CONNECTION# record, so seed one here.
+put({ PK: 'GAME#3005', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST', IsHost: true });
+const voteRes = await startVote({ pathParameters: { gameId: '3005' }, body: JSON.stringify({ questionNumber: 1 }) });
+const votePayload = JSON.parse(voteRes.body);
+
+await check('start-vote still returns 200', () =>
+  assert.strictEqual(voteRes.statusCode, 200));
+await check('the ballot carries all the answers', () =>
+  assert.strictEqual(votePayload.answers.length, 2));
+await check('no playerId — the label that named the answer', () =>
+  assert.ok(votePayload.answers.every(a => !('playerId' in a)),
+    `leaked: ${JSON.stringify(votePayload.answers[0])}`));
+await check('no playerName and no name', () =>
+  assert.ok(votePayload.answers.every(a => !('playerName' in a) && !('name' in a))));
+await check('answer order is untouched — the ballot runs on it', () =>
+  assert.deepStrictEqual(votePayload.answers.map(a => a.answer),
+    ["Ada's answer", "Grace's answer"]));
+
+// Regression guard for the fix in d9e58aae — this must not be lost.
+await check('votingStarted still carries newState', () =>
+  assert.strictEqual(sent[0]?.message?.newState, 'VOTE#001'));
+await check('votingStarted carries no attribution and never did', () => {
+  const frame = sent[0].message;
+  assert.ok(!('playerName' in frame) && !('answers' in frame),
+    'the broadcast has grown an attribution field');
+});
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);

--- a/tests/wavelength-ai-summary.js
+++ b/tests/wavelength-ai-summary.js
@@ -1,0 +1,320 @@
+/**
+ * A wavelength round must be able to produce Field Notes at all.
+ *
+ * The motivating failure: exports.handler's own vote-tally pass has a
+ * wavelength branch (get-ai-summary.js, the `else if (gameType ===
+ * 'wavelength')` arm that sets every player's team score) which read a bare
+ * `commonWords`. That identifier was only ever declared inside
+ * generateAISummary — a separate top-level function with no closure over the
+ * handler's locals — so the read was an undeclared-variable reference and every
+ * wavelength game threw `ReferenceError: commonWords is not defined` there.
+ *
+ * It threw BEFORE prompt resolution, before generateAISummary was called at
+ * all, so no prompt/persona/template configuration could avoid it: any
+ * wavelength round with at least one answer failed. In production the HTTP call
+ * still returned 202 "generating" (it self-invokes a worker), and the worker
+ * then crashed, broadcast `aiSummaryError` to the room and rethrew into
+ * Lambda's retries. Field Notes never appeared for wavelength.
+ *
+ * Sibling of tests/anonymous-round-flow.js, whose stub preamble this copies.
+ * That suite had to call generateAISummary() directly precisely because this
+ * bug made the exports.handler round trip unreachable for wavelength; these
+ * tests drive the real handler instead.
+ */
+const path = require('path');
+const assert = require('assert');
+
+const REPO = path.join(__dirname, '..');
+
+// ---- Stubs, installed before the handler loads -----------------------------
+class PutCommand { constructor(i) { this.input = i; this.type = 'put'; } }
+class GetCommand { constructor(i) { this.input = i; this.type = 'get'; } }
+class QueryCommand { constructor(i) { this.input = i; this.type = 'query'; } }
+class DeleteCommand { constructor(i) { this.input = i; this.type = 'delete'; } }
+class UpdateCommand { constructor(i) { this.input = i; this.type = 'update'; } }
+class ScanCommand { constructor(i) { this.input = i; this.type = 'scan'; } }
+class PostToConnectionCommand { constructor(i) { this.input = i; } }
+
+const store = new Map();
+const key = (pk, sk) => `${pk}|${sk}`;
+const put = (item) => store.set(key(item.PK, item.SK), item);
+
+/** Frames the handler tried to push, in order. */
+let sent = [];
+
+const fakeDoc = {
+  send: async (cmd) => {
+    const inp = cmd.input || {};
+    switch (cmd.type) {
+      case 'put':
+        store.set(key(inp.Item.PK, inp.Item.SK), inp.Item);
+        return {};
+      case 'get':
+        return { Item: store.get(key(inp.Key.PK, inp.Key.SK)) };
+      case 'delete':
+        store.delete(key(inp.Key.PK, inp.Key.SK));
+        return {};
+      case 'update':
+        return {};
+      case 'query': {
+        const pk = inp.ExpressionAttributeValues[':pk'];
+        const prefix = inp.ExpressionAttributeValues[':sk'] ?? '';
+        const items = [...store.values()].filter(
+          (i) => i.PK === pk && String(i.SK).startsWith(String(prefix))
+        );
+        return { Items: items, Count: items.length };
+      }
+      case 'scan': {
+        const values = inp.ExpressionAttributeValues || {};
+        const items = [...store.values()].filter((i) => {
+          if (values[':pk'] !== undefined && i.PK !== values[':pk']) return false;
+          if (values[':isDefault'] !== undefined && i.isDefault !== values[':isDefault']) return false;
+          return true;
+        });
+        return { Items: items, Count: items.length };
+      }
+      default:
+        return {};
+    }
+  },
+};
+
+class FakeApiGatewayClient {
+  async send(cmd) {
+    sent.push({ connectionId: cmd.input.ConnectionId, message: JSON.parse(cmd.input.Data) });
+    return {};
+  }
+}
+
+// Handlers live in lambda-functions/<group>/, each of which may carry its own
+// node_modules. Node resolves from the requiring file upward, so poison every
+// resolvable copy or the real SDK loads and the test dies on credentials.
+const STUB_PATHS = [
+  REPO,
+  path.join(REPO, 'lambda-functions'),
+  path.join(REPO, 'lambda-functions', 'game'),
+  path.join(REPO, 'lambda-functions', 'websocket'),
+];
+
+function stub(name, exports) {
+  const seen = new Set();
+  for (const base of STUB_PATHS) {
+    let p;
+    try { p = require.resolve(name, { paths: [base] }); } catch { continue; }
+    if (seen.has(p)) continue;
+    seen.add(p);
+    require.cache[p] = { id: p, filename: p, loaded: true, exports };
+  }
+  if (!seen.size) throw new Error(`stub(): could not resolve ${name}`);
+}
+
+stub('@aws-sdk/client-dynamodb', { DynamoDBClient: class {} });
+stub('@aws-sdk/lib-dynamodb', {
+  DynamoDBDocumentClient: { from: () => fakeDoc },
+  PutCommand, GetCommand, QueryCommand, DeleteCommand, UpdateCommand, ScanCommand,
+});
+stub('@aws-sdk/client-apigatewaymanagementapi', {
+  ApiGatewayManagementApiClient: FakeApiGatewayClient,
+  PostToConnectionCommand,
+});
+
+process.env.TABLE_NAME = 'test-table';
+process.env.WEBSOCKET_API_ENDPOINT = 'https://ws.test.invalid/dev';
+
+// @aws-sdk/client-s3 and @aws-sdk/client-lambda exist only in the deployed
+// bundle, so require.cache poisoning (which needs require.resolve to succeed)
+// cannot reach them — hook the loader by name. Bedrock IS resolvable locally
+// and would attempt a real network call, so stub it to fail fast: every test
+// here then exercises the deterministic fallback-summary path, which is the
+// same path a real throttle or outage takes. The Bedrock client is a
+// MODULE-LEVEL singleton, so this must be in place before the first require.
+const Module = require('module');
+const realLoad = Module._load;
+const noopClient = class { async send() { return {}; } };
+const throwingBedrock = class { async send() { throw new Error('stub: no Bedrock in tests'); } };
+const extraStubs = new Map([
+  ['@aws-sdk/client-s3', { S3Client: noopClient, GetObjectCommand: class {} }],
+  ['@aws-sdk/client-lambda', { LambdaClient: noopClient, InvokeCommand: class {} }],
+  ['@aws-sdk/client-bedrock-runtime', { BedrockRuntimeClient: throwingBedrock, InvokeModelCommand: class {} }],
+]);
+Module._load = function (request, parent, isMain) {
+  if (extraStubs.has(request)) return extraStubs.get(request);
+  return realLoad.call(this, request, parent, isMain);
+};
+const { handler: getAiSummary } = require(path.join(REPO, 'lambda-functions/game/get-ai-summary.js'));
+Module._load = realLoad;
+
+let pass = 0, fail = 0;
+async function check(label, fn) {
+  try { await fn(); console.log(`  PASS  ${label}`); pass++; }
+  catch (e) { console.log(`  FAIL  ${label}\n        ${e.message}`); fail++; }
+}
+
+// Enough of a template that prompt resolution succeeds and the assembled
+// prompt carries the wavelength variables. s3Key present + the stubbed S3
+// client resolving to a bodyless {} makes fetchPromptFromS3 fall through to its
+// own "use the DynamoDB record" fallback, which is the simplest way to supply a
+// usable .template without a real S3 object.
+const AI_PROMPT_TEMPLATE =
+  'Q: {questionTitle}\n' +
+  'RESPONSES: {responsesText}\n' +
+  'COMMON WORDS: {commonWords}\n' +
+  'WORD ANALYSIS: {wordAnalysis}\n' +
+  'TEAM SCORE: {teamScore}\n' +
+  '=== SUMMARY ===\nx\n=== DISCUSSION QUESTIONS ===\nQ1: x\n=== NEXT STEPS ===\nSTEP1: x';
+
+/**
+ * Seeds a wavelength round. Two players share two words ("ocean", "blue") out
+ * of four unique ones, so the correct common-word count is 2 and the correct
+ * connection rate 50% — numbers that are wrong in a visible way if the team
+ * score silently degrades to zero.
+ *
+ * `storedResults` mirrors what get-results.js's handleWavelengthResults
+ * actually persists under QUESTION#nnn#RESULTS, field for field.
+ */
+function seedWavelength(gameId, { withStoredResults = true, withPrompt = true } = {}) {
+  store.clear();
+  sent = [];
+  put({ PK: `GAME#${gameId}`, SK: 'METADATA', GameType: 'wavelength', Title: 'T',
+        QuestionSetId: 'wl-set', HostPreferences: {} });
+  put({ PK: `GAME#${gameId}`, SK: 'STATE', State: 'RESULTS#001', LessonNumber: 1, CurrentQuestionId: '001' });
+  put({ PK: `GAME#${gameId}`, SK: 'ROUND#001', QuestionNumber: '001', AuthorsRevealed: true });
+  put({ PK: `GAME#${gameId}`, SK: 'QUESTION#001#ANSWER#Ada', PlayerName: 'Ada',
+        Answer: 'ocean, blue, calm', ProcessedWords: ['ocean', 'blue', 'calm'],
+        SubmittedAt: '2026-01-01T00:00:00.000Z' });
+  put({ PK: `GAME#${gameId}`, SK: 'QUESTION#001#ANSWER#Grace', PlayerName: 'Grace',
+        Answer: 'ocean, deep, blue', ProcessedWords: ['ocean', 'deep', 'blue'],
+        SubmittedAt: '2026-01-01T00:00:00.000Z' });
+  put({ PK: `GAME#${gameId}`, SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+
+  if (withStoredResults) {
+    put({
+      PK: `GAME#${gameId}`, SK: 'QUESTION#001#RESULTS',
+      gameId, questionId: '001', gameType: 'wavelength',
+      answers: [
+        { playerName: 'Ada', answer: 'ocean, blue, calm', words: ['ocean', 'blue', 'calm'] },
+        { playerName: 'Grace', answer: 'ocean, deep, blue', words: ['ocean', 'deep', 'blue'] },
+      ],
+      wordAnalysis: {
+        totalAnswers: 2, totalWordsSubmitted: 6, totalUniqueWords: 4,
+        commonWords: [{ word: 'ocean', count: 2 }, { word: 'blue', count: 2 }],
+        wordCounts: { ocean: 2, blue: 2, calm: 1, deep: 1 },
+        connectionScore: 50,
+      },
+      teamScore: 2,
+    });
+  }
+  if (withPrompt) {
+    put({ PK: 'SETS', SK: 'SET#wl-set', setId: 'wl-set', gameType: 'wavelength', promptId: 'wavelength-default' });
+    put({ PK: 'AIPROMPTS', SK: 'AIPROMPT#wavelength-default', promptId: 'wavelength-default',
+          gameType: 'wavelength', isDefault: true, s3Key: 'fake-key', template: AI_PROMPT_TEMPLATE });
+  }
+}
+
+/** Drives the real worker path — the one production actually runs. */
+async function runWorker(gameId, opts) {
+  seedWavelength(gameId, opts);
+  const res = await getAiSummary({ __workerMode: true, gameId, questionId: '001', debug: 'true' });
+  return { res, stored: store.get(key(`GAME#${gameId}`, 'QUESTION#001#AISummary')) };
+}
+
+(async () => {
+
+console.log('\n1. a wavelength round reaches the end of the handler at all');
+
+await check('the worker completes instead of throwing ReferenceError', async () => {
+  const { res } = await runWorker('9101');
+  assert.strictEqual(res.ok, true, `worker did not report ok: ${JSON.stringify(res)}`);
+});
+
+await check('the summary is persisted', async () => {
+  const { stored } = await runWorker('9102');
+  assert.ok(stored, 'no QUESTION#001#AISummary record was written');
+});
+
+await check('the room is told the summary is ready, not that it errored', async () => {
+  await runWorker('9103');
+  const types = sent.map((s) => s.message.type);
+  assert.ok(types.includes('aiSummaryReady'), `broadcast types were ${JSON.stringify(types)}`);
+  assert.ok(!types.includes('aiSummaryError'), `broadcast an error: ${JSON.stringify(types)}`);
+});
+
+console.log('\n2. the team score is the real common-word count, not a silent zero');
+
+// The handler's wavelength arm gives every player the same team score. Nothing
+// downstream would have flagged a hardcoded 0 — it is a plausible-looking
+// score — so pin it to the seeded data: 2 shared words out of 4 unique.
+await check('every player is scored 2, the number of shared words', async () => {
+  const { stored } = await runWorker('9104');
+  const vars = stored.DebugInfo?.templateVariables || {};
+  assert.strictEqual(String(vars.teamScore), '2', `teamScore was ${vars.teamScore}`);
+});
+
+await check('the assembled prompt names the words that were actually shared', async () => {
+  const { stored } = await runWorker('9105');
+  const prompt = stored.DebugInfo?.fullPrompt || '';
+  assert.ok(/ocean/.test(prompt) && /blue/.test(prompt), `common words missing from prompt:\n${prompt}`);
+  assert.ok(!/\bcalm\b/.test(prompt.split('COMMON WORDS:')[1]?.split('\n')[0] || ''),
+    'listed a word only one player submitted as common');
+});
+
+console.log('\n3. a round whose results were never stored still works');
+
+// storedResults is a separate QUESTION#nnn#RESULTS record. It is absent for
+// rounds resolved before that write existed, and for any round whose results
+// call did not complete — so the handler cannot assume it.
+await check('no stored results: the worker still completes', async () => {
+  const { res } = await runWorker('9106', { withStoredResults: false });
+  assert.strictEqual(res.ok, true, `worker did not report ok: ${JSON.stringify(res)}`);
+});
+
+await check('no stored results: the score is recomputed from the answers, not zeroed', async () => {
+  const { stored } = await runWorker('9107', { withStoredResults: false });
+  const vars = stored.DebugInfo?.templateVariables || {};
+  assert.strictEqual(String(vars.teamScore), '2', `teamScore was ${vars.teamScore}`);
+});
+
+console.log('\n4. the handler and generateAISummary agree on the count');
+
+// These are two independent derivations of the same number: the handler's
+// vote-tally pass scores the players, generateAISummary builds the model's
+// word analysis. They read the same inputs and must not drift — a disagreement
+// means the room is shown one score while the model is told another.
+for (const [label, opts] of [['stored results', {}], ['recomputed', { withStoredResults: false }]]) {
+  await check(`${label}: teamScore matches the wordAnalysis common-word count`, async () => {
+    const { stored } = await runWorker('9108', opts);
+    const vars = stored.DebugInfo?.templateVariables || {};
+    const fromAnalysis = /^(\d+) common words found/.exec(vars.wordAnalysis || '');
+    assert.ok(fromAnalysis, `could not read a count out of wordAnalysis: ${vars.wordAnalysis}`);
+    assert.strictEqual(String(vars.teamScore), fromAnalysis[1],
+      `teamScore ${vars.teamScore} but wordAnalysis reported ${fromAnalysis[1]}`);
+  });
+}
+
+console.log('\n5. the other game types are unaffected');
+
+// The wavelength arm sits in an if/else chain with trivia and the vote-based
+// types. Scoring for those must be untouched by the fix.
+await check('a trivia round still scores from the points on each answer', async () => {
+  store.clear();
+  sent = [];
+  put({ PK: 'GAME#9109', SK: 'METADATA', GameType: 'trivia', Title: 'T', QuestionSetId: 'tr-set', HostPreferences: {} });
+  put({ PK: 'GAME#9109', SK: 'STATE', State: 'RESULTS#001', LessonNumber: 1, CurrentQuestionId: '001' });
+  put({ PK: 'GAME#9109', SK: 'ROUND#001', QuestionNumber: '001', AuthorsRevealed: true });
+  put({ PK: 'GAME#9109', SK: 'QUESTION#001#ANSWER#Ada', PlayerName: 'Ada', Answer: 'OptionA',
+        PointsEarned: 7, IsCorrect: true, SubmittedAt: '2026-01-01T00:00:00.000Z' });
+  put({ PK: 'GAME#9109', SK: 'CONNECTION#host-1', ConnectionId: 'host-1', ConnectionType: 'HOST' });
+  put({ PK: 'SETS', SK: 'SET#tr-set', setId: 'tr-set', gameType: 'trivia', promptId: 'trivia-default' });
+  put({ PK: 'AIPROMPTS', SK: 'AIPROMPT#trivia-default', promptId: 'trivia-default', gameType: 'trivia',
+        isDefault: true, s3Key: 'fake-key', template: AI_PROMPT_TEMPLATE + '\nSCORES: {roundScores}' });
+
+  const res = await getAiSummary({ __workerMode: true, gameId: '9109', questionId: '001', debug: 'true' });
+  assert.strictEqual(res.ok, true, `trivia worker did not report ok: ${JSON.stringify(res)}`);
+  const stored = store.get(key('GAME#9109', 'QUESTION#001#AISummary'));
+  assert.ok(/7/.test(stored.DebugInfo?.fullPrompt || ''), 'the 7 points earned did not reach the prompt');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);
+
+})();


### PR DESCRIPTION
## The bug

`exports.handler`'s own vote-tally pass in `lambda-functions/game/get-ai-summary.js` read a bare `commonWords` to work out the shared team score. That identifier is declared only inside `generateAISummary` — a separate top-level function with no closure over the handler's locals — so the read was an undeclared-variable reference:

```
ReferenceError: commonWords is not defined
    at exports.handler (lambda-functions/game/get-ai-summary.js:866)
```

It threw **before** prompt resolution and before `generateAISummary` was called at all, so no prompt, persona or template configuration could avoid it. Any wavelength round with at least one answer failed.

What the room saw: the HTTP call still returned `202 {"status":"generating"}` (it self-invokes a worker), then the worker crashed, broadcast `aiSummaryError` and rethrew into Lambda's retries. Field Notes have never worked for this game type.

## How it was confirmed

Reproduced against a stubbed table by driving the real handler for a seeded wavelength round — with a valid prompt, with no prompt at all, and with no stored `#RESULTS` record. All three threw. Reachability is not theoretical: `wavelength` is a canonical id in `game-types.js` and is stored verbatim as `GameType`.

## The fix

`deriveWavelengthCommonWords(storedResults, answers)` prefers the `QUESTION#nnn#RESULTS` record the handler already fetches, and otherwise recounts words shared by 2+ participants using the same rule `get-results.js` used.

One derivation because two scopes need the number — the handler scores the players, `generateAISummary` briefs the model — and if they disagree the room is shown one score while the model is told another. It returns counts only, never author names, so it is safe to call while a round is still anonymous.

## Tests

New suite `tests/wavelength-ai-summary.js` drives the real worker path end to end. Before this change: **1 passed, 9 failed** (every wavelength check on the ReferenceError; the trivia control passed). After: **10 passed, 0 failed**.

The checks pin the team score to the seeded value of 2 rather than just asserting "does not throw" — a silent `0` is a plausible-looking score that nothing else would catch — and assert the handler and `generateAISummary` agree on the count in both the stored and recomputed paths.

Full backend suite: **20 suites / 720 passed** before, **21 suites / 730 passed** after, 0 failed either way.

## Note on the base

This branches off `dev`, so it carries the 17 held anonymous-responses commits underneath it. The fix depends on one of them (`e3fc7711`, which threads `storedResults` into `generateAISummary`) — on `origin/dev` this change alone would only trade `ReferenceError: commonWords` for `ReferenceError: storedResults`. Merging this therefore also releases that held work, with the deploy consequences described in `44b1d292`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)